### PR TITLE
chore: rename cosi-runtime to runtime

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,11 +105,11 @@ steps:
   depends_on:
   - unit-tests
 
-- name: cosi-runtime
+- name: runtime
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make cosi-runtime
+  - make runtime
   volumes:
   - name: outer-docker-socket
     path: /var/outer-run
@@ -139,11 +139,11 @@ steps:
   depends_on:
   - base
 
-- name: image-cosi-runtime
+- name: image-runtime
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make image-cosi-runtime
+  - make image-runtime
   volumes:
   - name: outer-docker-socket
     path: /var/outer-run
@@ -154,16 +154,16 @@ steps:
   - name: ssh
     path: /root/.ssh
   depends_on:
-  - cosi-runtime
+  - runtime
   - lint
   - unit-tests
 
-- name: push-cosi-runtime
+- name: push-runtime
   pull: always
   image: autonomy/build-container:latest
   commands:
   - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
-  - make image-cosi-runtime
+  - make image-runtime
   environment:
     GHCR_PASSWORD:
       from_secret: ghcr_token
@@ -184,14 +184,14 @@ steps:
       exclude:
       - pull_request
   depends_on:
-  - image-cosi-runtime
+  - image-runtime
 
-- name: push-cosi-runtime-latest
+- name: push-runtime-latest
   pull: always
   image: autonomy/build-container:latest
   commands:
   - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
-  - make image-cosi-runtime TAG=latest
+  - make image-runtime TAG=latest
   environment:
     GHCR_PASSWORD:
       from_secret: ghcr_token
@@ -214,7 +214,7 @@ steps:
       exclude:
       - pull_request
   depends_on:
-  - push-cosi-runtime
+  - push-runtime
 
 services:
 - name: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,20 @@ jobs:
         name: lint
         run: make lint
       -
-        name: cosi-runtime
-        run: make cosi-runtime
+        name: runtime
+        run: make runtime
       -
-        name: image-cosi-runtime
-        run: make image-cosi-runtime
+        name: image-runtime
+        run: make image-runtime
       -
-        name: push-image-cosi-runtime
+        name: push-image-runtime
         if: github.ref == 'refs/heads/master'
         env:
           PUSH: "true"
-        run: make image-cosi-runtime
+        run: make image-runtime
       -
-        name: push-image-cosi-runtime-latest
+        name: push-image-runtime-latest
         if: github.ref == 'refs/heads/master'
         env:
           PUSH: "true"
-        run: make image-cosi-runtime TAG=latest
+        run: make image-runtime TAG=latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,19 +94,19 @@ COPY --from=proto-compile /api/ /api/
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage.txt
 
-# builds cosi-runtime
-FROM base AS cosi-runtime-build
+# builds runtime
+FROM base AS runtime-build
 COPY --from=generate / /
-WORKDIR /src/cmd/cosi-runtime
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w" -o /cosi-runtime
+WORKDIR /src/cmd/runtime
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w" -o /runtime
 
-FROM scratch AS cosi-runtime
-COPY --from=cosi-runtime-build /cosi-runtime /cosi-runtime
+FROM scratch AS runtime
+COPY --from=runtime-build /runtime /runtime
 
-FROM scratch AS image-cosi-runtime
-COPY --from=cosi-runtime / /
+FROM scratch AS image-runtime
+COPY --from=runtime / /
 COPY --from=image-fhs / /
 COPY --from=image-ca-certificates / /
 LABEL org.opencontainers.image.source https://github.com/cosi-project/runtime
-ENTRYPOINT ["/cosi-runtime"]
+ENTRYPOINT ["/runtime"]
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ respectively.
 
 endef
 
-all: unit-tests cosi-runtime image-cosi-runtime lint
+all: unit-tests runtime image-runtime lint
 
 .PHONY: clean
 clean:  ## Cleans up all artifacts.
@@ -117,12 +117,12 @@ unit-tests-race:  ## Performs unit tests with race detection enabled.
 coverage:  ## Upload coverage data to codecov.io.
 	bash -c "bash <(curl -s https://codecov.io/bash) -f $(ARTIFACTS)/coverage.txt -X fix"
 
-.PHONY: $(ARTIFACTS)/cosi-runtime
-$(ARTIFACTS)/cosi-runtime:
-	@$(MAKE) local-cosi-runtime DEST=$(ARTIFACTS)
+.PHONY: $(ARTIFACTS)/runtime
+$(ARTIFACTS)/runtime:
+	@$(MAKE) local-runtime DEST=$(ARTIFACTS)
 
-.PHONY: cosi-runtime
-cosi-runtime: $(ARTIFACTS)/cosi-runtime  ## Builds executable for cosi-runtime.
+.PHONY: runtime
+runtime: $(ARTIFACTS)/runtime  ## Builds executable for runtime.
 
 .PHONY: lint-markdown
 lint-markdown:  ## Runs markdownlint.
@@ -131,9 +131,9 @@ lint-markdown:  ## Runs markdownlint.
 .PHONY: lint
 lint: lint-golangci-lint lint-gofumpt lint-markdown  ## Run all linters for the project.
 
-.PHONY: image-cosi-runtime
-image-cosi-runtime:  ## Builds image for cosi-runtime.
-	@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/cosi-runtime:$(TAG)"
+.PHONY: image-runtime
+image-runtime:  ## Builds image for runtime.
+	@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/runtime:$(TAG)"
 
 .PHONY: rekres
 rekres:

--- a/cmd/runtime/main.go
+++ b/cmd/runtime/main.go
@@ -74,7 +74,7 @@ func run() error {
 	v1alpha1.RegisterControllerRuntimeServer(grpcServer, grpcRuntime)
 	v1alpha1.RegisterControllerAdapterServer(grpcServer, grpcRuntime)
 
-	log.Printf("starting cosi-runtime service on %q", socketPath)
+	log.Printf("starting runtime service on %q", socketPath)
 
 	var eg errgroup.Group
 


### PR DESCRIPTION
Since the runtime now lives under the COSI project, we don't need "cosi"
in the name. We also discussed the general practice of not using the
project name (COSI) in the implementation. This change renames
"cosi-runtime" to "runtime" to align the project with this decision.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>