### PR TITLE
feat: add sensitivity to RDs

### DIFF
--- a/pkg/resource/meta/resource_definition.go
+++ b/pkg/resource/meta/resource_definition.go
@@ -31,12 +31,16 @@ type PrintColumn struct {
 }
 
 // ResourceDefinitionSpec provides ResourceDefinition definition.
-type ResourceDefinitionSpec struct {
+type ResourceDefinitionSpec struct { //nolint:govet
 	Type             resource.Type      `yaml:"type"`
 	DisplayType      string             `yaml:"displayType"`
 	DefaultNamespace resource.Namespace `yaml:"defaultNamespace"`
 	Aliases          []resource.Type    `yaml:"aliases"`
 	PrintColumns     []PrintColumn      `yaml:"printColumns"`
+
+	// Sensitivity indicates how secret resource of this type is.
+	// The empty value represents a non-sensitive resource.
+	Sensitivity Sensitivity `yaml:"sensitivity,omitempty"`
 }
 
 // ID computes id of the resource definition.
@@ -106,6 +110,10 @@ func (spec *ResourceDefinitionSpec) Fill() error {
 		if !strings.HasSuffix(upperLetters, "S") {
 			spec.Aliases = append(spec.Aliases, strings.ToLower(upperLetters+"s"))
 		}
+	}
+
+	if _, ok := allSensitivities[spec.Sensitivity]; !ok {
+		return fmt.Errorf("unknown sensitivity %q", spec.Sensitivity)
 	}
 
 	return nil

--- a/pkg/resource/meta/resource_definition_test.go
+++ b/pkg/resource/meta/resource_definition_test.go
@@ -36,7 +36,7 @@ func TestNSSpec(t *testing.T) {
 }
 
 func TestRDSpecValidation(t *testing.T) {
-	for _, tt := range []struct { //nolint: govet
+	for _, tt := range []struct {
 		name          string
 		spec          meta.ResourceDefinitionSpec
 		expectedError string

--- a/pkg/resource/meta/sensitivity.go
+++ b/pkg/resource/meta/sensitivity.go
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package meta
+
+// Sensitivity indicates how secret resource is.
+// The empty value represents a non-sensitive resource.
+type Sensitivity string
+
+// Sensitivity values.
+const (
+	NonSensitive Sensitivity = ""
+	Sensitive    Sensitivity = "sensitive"
+)
+
+var allSensitivities = map[Sensitivity]struct{}{
+	NonSensitive: {},
+	Sensitive:    {},
+}


### PR DESCRIPTION
Sensitivity indicates how secret resource of this type is.
The empty value represents a non-sensitive resource.
