### PR TITLE
feat: add state filtering facility

### DIFF
--- a/pkg/state/filter.go
+++ b/pkg/state/filter.go
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package state
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+)
+
+// Filter state access by some rules.
+//
+// Filter allows building RBAC access pattern or any other kinds of restictions.
+func Filter(coreState CoreState, rule FilteringRule) CoreState {
+	return &stateFilter{
+		state: coreState,
+		rule:  rule,
+	}
+}
+
+// FilteringRule defines a function which gets invoked on each state access.
+//
+// Function might allow access by returning nil or deny access by returning an error
+// which will be returned to the caller.
+type FilteringRule func(ctx context.Context, access Access) error
+
+// Access describes state API access in a generic way.
+type Access struct {
+	ResourceNamespace resource.Namespace
+	ResourceType      resource.Type
+	ResourceID        resource.ID
+
+	Verb Verb
+}
+
+// Verb is API verb.
+type Verb int
+
+// Verb definitions.
+const (
+	Get Verb = iota
+	List
+	Watch
+	Create
+	Update
+	Destroy
+)
+
+// Readonly returns true for verbs which don't modify data.
+func (verb Verb) Readonly() bool {
+	return verb == Get || verb == List || verb == Watch
+}
+
+type stateFilter struct {
+	state CoreState
+	rule  FilteringRule
+}
+
+// Get a resource by type and ID.
+//
+// If a resource is not found, error is returned.
+func (filter *stateFilter) Get(ctx context.Context, resourcePointer resource.Pointer, opts ...GetOption) (resource.Resource, error) {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: resourcePointer.Namespace(),
+		ResourceType:      resourcePointer.Type(),
+		ResourceID:        resourcePointer.ID(),
+
+		Verb: Get,
+	}); err != nil {
+		return nil, err
+	}
+
+	return filter.state.Get(ctx, resourcePointer, opts...)
+}
+
+// List resources by type.
+func (filter *stateFilter) List(ctx context.Context, resourceKind resource.Kind, opts ...ListOption) (resource.List, error) {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: resourceKind.Namespace(),
+		ResourceType:      resourceKind.Type(),
+
+		Verb: List,
+	}); err != nil {
+		return resource.List{}, err
+	}
+
+	return filter.state.List(ctx, resourceKind, opts...)
+}
+
+// Create a resource.
+//
+// If a resource already exists, Create returns an error.
+func (filter *stateFilter) Create(ctx context.Context, res resource.Resource, opts ...CreateOption) error {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: res.Metadata().Namespace(),
+		ResourceType:      res.Metadata().Type(),
+		ResourceID:        res.Metadata().ID(),
+
+		Verb: Create,
+	}); err != nil {
+		return err
+	}
+
+	return filter.state.Create(ctx, res, opts...)
+}
+
+// Update a resource.
+//
+// If a resource doesn't exist, error is returned.
+// On update current version of resource `new` in the state should match
+// curVersion, otherwise conflict error is returned.
+func (filter *stateFilter) Update(ctx context.Context, curVersion resource.Version, newResource resource.Resource, opts ...UpdateOption) error {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: newResource.Metadata().Namespace(),
+		ResourceType:      newResource.Metadata().Type(),
+		ResourceID:        newResource.Metadata().ID(),
+
+		Verb: Update,
+	}); err != nil {
+		return err
+	}
+
+	return filter.state.Update(ctx, curVersion, newResource, opts...)
+}
+
+// Destroy a resource.
+//
+// If a resource doesn't exist, error is returned.
+// If a resource has pending finalizers, error is returned.
+func (filter *stateFilter) Destroy(ctx context.Context, resourcePointer resource.Pointer, opts ...DestroyOption) error {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: resourcePointer.Namespace(),
+		ResourceType:      resourcePointer.Type(),
+		ResourceID:        resourcePointer.ID(),
+
+		Verb: Destroy,
+	}); err != nil {
+		return err
+	}
+
+	return filter.state.Destroy(ctx, resourcePointer, opts...)
+}
+
+// Watch state of a resource by type.
+//
+// It's fine to watch for a resource which doesn't exist yet.
+// Watch is canceled when context gets canceled.
+// Watch sends initial resource state as the very first event on the channel,
+// and then sends any updates to the resource as events.
+func (filter *stateFilter) Watch(ctx context.Context, resourcePointer resource.Pointer, ch chan<- Event, opts ...WatchOption) error {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: resourcePointer.Namespace(),
+		ResourceType:      resourcePointer.Type(),
+		ResourceID:        resourcePointer.ID(),
+
+		Verb: Watch,
+	}); err != nil {
+		return err
+	}
+
+	return filter.state.Watch(ctx, resourcePointer, ch, opts...)
+}
+
+// WatchKind watches resources of specific kind (namespace and type).
+func (filter *stateFilter) WatchKind(ctx context.Context, resourceKind resource.Kind, ch chan<- Event, opts ...WatchKindOption) error {
+	if err := filter.rule(ctx, Access{
+		ResourceNamespace: resourceKind.Namespace(),
+		ResourceType:      resourceKind.Type(),
+
+		Verb: Watch,
+	}); err != nil {
+		return err
+	}
+
+	return filter.state.WatchKind(ctx, resourceKind, ch, opts...)
+}

--- a/pkg/state/filter_test.go
+++ b/pkg/state/filter_test.go
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package state_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/conformance"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+)
+
+func TestFilterPasshtroughConformance(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &conformance.StateSuite{
+		State: state.WrapCore(
+			state.Filter(
+				namespaced.NewState(inmem.Build),
+				func(context.Context, state.Access) error {
+					return nil
+				},
+			),
+		),
+		Namespaces: []resource.Namespace{"default", "controller", "system", "runtime"},
+	})
+}
+
+func TestFilterSingleResource(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace    = "default"
+		resourceType = conformance.PathResourceType
+		resourceID   = "/var/lib"
+	)
+
+	resources := state.WrapCore(
+		state.Filter(
+			namespaced.NewState(inmem.Build),
+			func(ctx context.Context, access state.Access) error {
+				if access.ResourceNamespace != namespace || access.ResourceType != resourceType || access.ResourceID != resourceID {
+					return fmt.Errorf("access denied")
+				}
+
+				if access.Verb == state.Watch {
+					return fmt.Errorf("access denied")
+				}
+
+				return nil
+			},
+		),
+	)
+
+	path := conformance.NewPathResource(namespace, resourceID)
+	require.NoError(t, resources.Create(context.Background(), path))
+
+	path2 := conformance.NewPathResource(namespace, resourceID+"/exta")
+	require.Error(t, resources.Create(context.Background(), path2))
+
+	_, err := resources.List(context.Background(), path.Metadata())
+	require.Error(t, err)
+
+	require.Error(t, resources.Watch(context.Background(), path.Metadata(), nil))
+	require.Error(t, resources.WatchKind(context.Background(), path.Metadata(), nil))
+
+	destroyReady, err := resources.Teardown(context.Background(), path.Metadata())
+	require.NoError(t, err)
+	assert.True(t, destroyReady)
+
+	require.NoError(t, resources.Destroy(context.Background(), path.Metadata()))
+}


### PR DESCRIPTION
This implements generic filter which allows to limit access to the
resource API with some rule. For example, RBAC might be implemented this
way.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>