### PR TITLE
fix: make default resource watch history more shallow

### DIFF
--- a/pkg/state/impl/inmem/collection.go
+++ b/pkg/state/impl/inmem/collection.go
@@ -33,12 +33,7 @@ type ResourceCollection struct {
 }
 
 // NewResourceCollection returns new ResourceCollection.
-func NewResourceCollection(ns resource.Namespace, typ resource.Type) *ResourceCollection {
-	const (
-		capacity = 1000
-		gap      = 10
-	)
-
+func NewResourceCollection(ns resource.Namespace, typ resource.Type, capacity, gap int) *ResourceCollection {
 	collection := &ResourceCollection{
 		ns:       ns,
 		typ:      typ,

--- a/pkg/state/impl/inmem/options.go
+++ b/pkg/state/impl/inmem/options.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package inmem
+
+// StateOptions configure inmem.State.
+type StateOptions struct {
+	HistoryCapacity int
+	HistoryGap      int
+}
+
+// StateOption applies settings to StateOptions.
+type StateOption func(options *StateOptions)
+
+// WithHistoryCapacity sets history depth for a given namspace and resource.
+//
+// Deep history requires more memory, but allows Watch request to return more historical entries, and also
+// acts like a buffer if watch consumer can't keep up with events.
+func WithHistoryCapacity(capacity int) StateOption {
+	return func(options *StateOptions) {
+		options.HistoryCapacity = capacity
+	}
+}
+
+// WithHistoryGap sets a safety gap between watch events consumers and events producers.
+//
+// Bigger gap reduces effective history depth (HistoryCapacity - HistoryGap).
+// Smaller gap might result in buffer overruns if consumer can't keep up with the events.
+// It's recommended to have gap 5% of the capacity.
+func WithHistoryGap(gap int) StateOption {
+	return func(options *StateOptions) {
+		options.HistoryGap = gap
+	}
+}
+
+// DefaultStateOptions returns default value of StateOptions.
+func DefaultStateOptions() StateOptions {
+	return StateOptions{
+		HistoryCapacity: 100,
+		HistoryGap:      5,
+	}
+}

--- a/pkg/state/options.go
+++ b/pkg/state/options.go
@@ -7,9 +7,7 @@ package state
 import "github.com/cosi-project/runtime/pkg/resource"
 
 // GetOptions for the CoreState.Get function.
-type GetOptions struct {
-	Owner string
-}
+type GetOptions struct{}
 
 // GetOption builds GetOptions.
 type GetOption func(*GetOptions)


### PR DESCRIPTION
This reduce history depth from 1000 entries to 100 entries (for each
resource type under a namespace). The main benefit is memory savings.

Also gc unused and never implemented option.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>