### PR TITLE
refactor: remove fmt.Stringer from resource.Resource interface

### DIFF
--- a/pkg/controller/conformance/controllers.go
+++ b/pkg/controller/conformance/controllers.go
@@ -78,7 +78,7 @@ func (ctrl *IntToStrController) Run(ctx context.Context, r controller.Runtime, l
 
 			switch intRes.Metadata().Phase() {
 			case resource.PhaseRunning:
-				if err = r.AddFinalizer(ctx, intRes.Metadata(), strRes.String()); err != nil {
+				if err = r.AddFinalizer(ctx, intRes.Metadata(), resource.String(strRes)); err != nil {
 					return fmt.Errorf("error adding finalizer: %w", err)
 				}
 
@@ -105,7 +105,7 @@ func (ctrl *IntToStrController) Run(ctx context.Context, r controller.Runtime, l
 					return fmt.Errorf("error destroying: %w", err)
 				}
 
-				if err = r.RemoveFinalizer(ctx, intRes.Metadata(), strRes.String()); err != nil {
+				if err = r.RemoveFinalizer(ctx, intRes.Metadata(), resource.String(strRes)); err != nil {
 					if !state.IsNotFoundError(err) {
 						return fmt.Errorf("error removing finalizer (str controller): %w", err)
 					}
@@ -181,7 +181,7 @@ func (ctrl *StrToSentenceController) Run(ctx context.Context, r controller.Runti
 
 			switch strRes.Metadata().Phase() {
 			case resource.PhaseRunning:
-				if err = r.AddFinalizer(ctx, strRes.Metadata(), sentenceRes.String()); err != nil {
+				if err = r.AddFinalizer(ctx, strRes.Metadata(), resource.String(sentenceRes)); err != nil {
 					return fmt.Errorf("error adding finalizer: %w", err)
 				}
 
@@ -207,7 +207,7 @@ func (ctrl *StrToSentenceController) Run(ctx context.Context, r controller.Runti
 					return fmt.Errorf("error destroying: %w", err)
 				}
 
-				if err = r.RemoveFinalizer(ctx, strRes.Metadata(), sentenceRes.String()); err != nil {
+				if err = r.RemoveFinalizer(ctx, strRes.Metadata(), resource.String(sentenceRes)); err != nil {
 					return fmt.Errorf("error removing finalizer (sentence controller): %w", err)
 				}
 			}

--- a/pkg/controller/conformance/resources.go
+++ b/pkg/controller/conformance/resources.go
@@ -6,7 +6,6 @@ package conformance
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 )
@@ -75,10 +74,6 @@ func (r *IntResource) SetValue(v int) {
 	r.value.value = v
 }
 
-func (r *IntResource) String() string {
-	return fmt.Sprintf("IntResource(%q -> %d)", r.md.ID(), r.value.value)
-}
-
 // DeepCopy implements resource.Resource.
 func (r *IntResource) DeepCopy() resource.Resource {
 	return &IntResource{
@@ -145,10 +140,6 @@ func (r *StrResource) SetValue(v string) {
 	r.value.value = v
 }
 
-func (r *StrResource) String() string {
-	return fmt.Sprintf("StrResource(%q -> %q)", r.md.ID(), r.value.value)
-}
-
 // DeepCopy implements resource.Resource.
 func (r *StrResource) DeepCopy() resource.Resource {
 	return &StrResource{
@@ -203,10 +194,6 @@ func (r *SentenceResource) Value() string {
 // SetValue implements StringResource.
 func (r *SentenceResource) SetValue(v string) {
 	r.value.value = v
-}
-
-func (r *SentenceResource) String() string {
-	return fmt.Sprintf("SentenceResource(%q -> %q)", r.md.ID(), r.value.value)
 }
 
 // DeepCopy implements resource.Resource.

--- a/pkg/resource/any.go
+++ b/pkg/resource/any.go
@@ -5,8 +5,6 @@
 package resource
 
 import (
-	"fmt"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -65,10 +63,6 @@ func (a *Any) Spec() interface{} {
 // Value returns decoded value as Go type.
 func (a *Any) Value() interface{} {
 	return a.spec.value
-}
-
-func (a *Any) String() string {
-	return fmt.Sprintf("Any(%s)", a.md)
 }
 
 // DeepCopy implements resource.Resource.

--- a/pkg/resource/meta/namespace.go
+++ b/pkg/resource/meta/namespace.go
@@ -5,8 +5,6 @@
 package meta
 
 import (
-	"fmt"
-
 	"github.com/cosi-project/runtime/pkg/resource"
 )
 
@@ -44,10 +42,6 @@ func (r *Namespace) Metadata() *resource.Metadata {
 // Spec implements resource.Resource.
 func (r *Namespace) Spec() interface{} {
 	return r.spec
-}
-
-func (r *Namespace) String() string {
-	return fmt.Sprintf("Namespace(%q)", r.md.ID())
 }
 
 // DeepCopy implements resource.Resource.

--- a/pkg/resource/meta/resource_definition.go
+++ b/pkg/resource/meta/resource_definition.go
@@ -159,10 +159,6 @@ func (r *ResourceDefinition) Spec() interface{} {
 	return r.spec
 }
 
-func (r *ResourceDefinition) String() string {
-	return fmt.Sprintf("ResourceDefinition(%q)", r.md.ID())
-}
-
 // DeepCopy implements resource.Resource.
 func (r *ResourceDefinition) DeepCopy() resource.Resource {
 	return &ResourceDefinition{

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -27,9 +27,6 @@ type (
 // Resource might have additional opaque data in Spec().
 // When resource is updated, Version should change with each update.
 type Resource interface {
-	// String() method for debugging/logging.
-	fmt.Stringer
-
 	// Metadata for the resource.
 	//
 	// Metadata.Version should change each time Spec changes.
@@ -60,4 +57,11 @@ func MarshalYAML(r Resource) (interface{}, error) {
 		Metadata: r.Metadata(),
 		Spec:     r.Spec(),
 	}, nil
+}
+
+// String returns representation suitable for %s formatting.
+func String(r Resource) string {
+	md := r.Metadata()
+
+	return fmt.Sprintf("%s(%s/%s)", md.Type(), md.Namespace(), md.ID())
 }

--- a/pkg/state/conformance/resources.go
+++ b/pkg/state/conformance/resources.go
@@ -46,10 +46,6 @@ func (path *PathResource) Spec() interface{} {
 	return pathSpec{}
 }
 
-func (path *PathResource) String() string {
-	return fmt.Sprintf("PathResource(%q)", path.md.ID())
-}
-
 // DeepCopy implements resource.Resource.
 func (path *PathResource) DeepCopy() resource.Resource {
 	return &PathResource{

--- a/pkg/state/conformance/state.go
+++ b/pkg/state/conformance/state.go
@@ -40,7 +40,7 @@ func (suite *StateSuite) TestCRD() {
 	path1 := NewPathResource(suite.getNamespace(), "var/run")
 	path2 := NewPathResource(suite.getNamespace(), "var/lib")
 
-	suite.Require().NotEqual(path1.String(), path2.String())
+	suite.Require().NotEqual(resource.String(path1), resource.String(path2))
 
 	ctx := context.Background()
 
@@ -61,11 +61,11 @@ func (suite *StateSuite) TestCRD() {
 
 	r, err := suite.State.Get(ctx, path1.Metadata())
 	suite.Require().NoError(err)
-	suite.Assert().Equal(path1.String(), r.String())
+	suite.Assert().Equal(resource.String(path1), resource.String(r))
 
 	r, err = suite.State.Get(ctx, path2.Metadata())
 	suite.Require().NoError(err)
-	suite.Assert().Equal(path2.String(), r.String())
+	suite.Assert().Equal(resource.String(path2), resource.String(r))
 
 	for _, res := range []resource.Resource{path1, path2} {
 		list, err = suite.State.List(ctx, res.Metadata())
@@ -77,14 +77,14 @@ func (suite *StateSuite) TestCRD() {
 			ids := make([]string, len(list.Items))
 
 			for i := range ids {
-				ids[i] = list.Items[i].String()
+				ids[i] = resource.String(list.Items[i])
 			}
 
-			suite.Assert().Equal([]string{path2.String(), path1.String()}, ids)
+			suite.Assert().Equal([]string{resource.String(path2), resource.String(path1)}, ids)
 		} else {
 			suite.Assert().Len(list.Items, 1)
 
-			suite.Assert().Equal(res.String(), list.Items[0].String())
+			suite.Assert().Equal(resource.String(res), resource.String(list.Items[0]))
 		}
 	}
 
@@ -113,7 +113,7 @@ func (suite *StateSuite) TestCRD() {
 	list, err = suite.State.List(ctx, path2.Metadata())
 	suite.Require().NoError(err)
 	suite.Assert().Len(list.Items, 1)
-	suite.Assert().Equal(path2.String(), list.Items[0].String())
+	suite.Assert().Equal(resource.String(path2), resource.String(list.Items[0]))
 
 	destroyReady, err = suite.State.Teardown(ctx, path2.Metadata())
 	suite.Require().NoError(err)
@@ -129,7 +129,7 @@ func (suite *StateSuite) TestCRDWithOwners() {
 
 	owner1, owner2 := "owner1", "owner2"
 
-	suite.Require().NotEqual(path1.String(), path2.String())
+	suite.Require().NotEqual(resource.String(path1), resource.String(path2))
 
 	ctx := context.Background()
 
@@ -138,12 +138,12 @@ func (suite *StateSuite) TestCRDWithOwners() {
 
 	r, err := suite.State.Get(ctx, path1.Metadata())
 	suite.Require().NoError(err)
-	suite.Assert().Equal(path1.String(), r.String())
+	suite.Assert().Equal(resource.String(path1), resource.String(r))
 	suite.Assert().Equal(owner1, r.Metadata().Owner())
 
 	r, err = suite.State.Get(ctx, path2.Metadata())
 	suite.Require().NoError(err)
-	suite.Assert().Equal(path2.String(), r.String())
+	suite.Assert().Equal(resource.String(path2), resource.String(r))
 	suite.Assert().Equal(owner2, r.Metadata().Owner())
 
 	oldVersion := r.Metadata().Version()
@@ -203,7 +203,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Created, event.Type)
-		suite.Assert().Equal(path2.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path2), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):
@@ -217,7 +217,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):
@@ -227,7 +227,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Destroyed, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):
@@ -242,7 +242,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path2.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path2), resource.String(event.Resource))
 		suite.Assert().Equal(path2.Metadata().Version(), event.Resource.Metadata().Version())
 
 		expectedEvents[event] = struct{}{}
@@ -261,7 +261,7 @@ func (suite *StateSuite) TestWatchKind() {
 		select {
 		case event := <-chWithBootstrap:
 			suite.Assert().Equal(state.Created, event.Type)
-			suite.Assert().Equal(res.String(), event.Resource.String())
+			suite.Assert().Equal(resource.String(res), resource.String(event.Resource))
 			suite.Assert().Equal(res.Metadata().Version(), event.Resource.Metadata().Version())
 		case <-time.After(time.Second):
 			suite.FailNow("timed out waiting for event")
@@ -276,7 +276,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path2.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path2), resource.String(event.Resource))
 		suite.Assert().Equal(path2.Metadata().Version(), event.Resource.Metadata().Version())
 
 		expectedEvents[event] = struct{}{}
@@ -287,7 +287,7 @@ func (suite *StateSuite) TestWatchKind() {
 	select {
 	case event := <-chWithBootstrap:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path2.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path2), resource.String(event.Resource))
 		suite.Assert().Equal(path2.Metadata().Version(), event.Resource.Metadata().Version())
 	case <-time.After(time.Second):
 		suite.FailNow("timed out waiting for event")
@@ -464,7 +464,7 @@ func (suite *StateSuite) TestWatch() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Created, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 		suite.Assert().Equal(path1.Metadata().Version(), event.Resource.Metadata().Version())
 
 		expectedEvents[event] = struct{}{}
@@ -479,7 +479,7 @@ func (suite *StateSuite) TestWatch() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 		suite.Assert().Equal(resource.PhaseTearingDown, event.Resource.Metadata().Phase())
 
 		expectedEvents[event] = struct{}{}
@@ -492,7 +492,7 @@ func (suite *StateSuite) TestWatch() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):
@@ -504,7 +504,7 @@ func (suite *StateSuite) TestWatch() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Updated, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):
@@ -516,7 +516,7 @@ func (suite *StateSuite) TestWatch() {
 	select {
 	case event := <-ch:
 		suite.Assert().Equal(state.Destroyed, event.Type)
-		suite.Assert().Equal(path1.String(), event.Resource.String())
+		suite.Assert().Equal(resource.String(path1), resource.String(event.Resource))
 
 		expectedEvents[event] = struct{}{}
 	case <-time.After(time.Second):


### PR DESCRIPTION
It is not being used almost anywhere, and implementing it for every
resource is a lot of routine work.

It is now implemented in a generic way as a `resource.String` function.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>