### PR TITLE
chore: refactor namespace and resource_definition resources

### DIFF
--- a/pkg/resource/meta/namespace.go
+++ b/pkg/resource/meta/namespace.go
@@ -6,15 +6,33 @@ package meta
 
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // NamespaceType is the type of Namespace.
 const NamespaceType = resource.Type("Namespaces.meta.cosi.dev")
 
 // Namespace provides metadata about namespaces.
-type Namespace struct {
-	spec NamespaceSpec
-	md   resource.Metadata
+type Namespace = typed.Resource[NamespaceSpec, NamespaceRD]
+
+// NewNamespace initializes a Namespace resource.
+func NewNamespace(id resource.ID, spec NamespaceSpec) *Namespace {
+	return typed.NewResource[NamespaceSpec, NamespaceRD](
+		resource.NewMetadata(NamespaceName, NamespaceType, id, resource.VersionUndefined),
+		spec,
+	)
+}
+
+// NamespaceRD provides auxiliary methods for Namespace.
+type NamespaceRD struct{}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (NamespaceRD) ResourceDefinition(_ resource.Metadata, _ NamespaceSpec) ResourceDefinitionSpec {
+	return ResourceDefinitionSpec{
+		Type:             NamespaceType,
+		DefaultNamespace: NamespaceName,
+		Aliases:          []resource.Type{"ns"},
+	}
 }
 
 // NamespaceSpec provides Namespace definition.
@@ -22,41 +40,7 @@ type NamespaceSpec struct {
 	Description string `yaml:"description"`
 }
 
-// NewNamespace initializes a Namespace resource.
-func NewNamespace(id resource.ID, spec NamespaceSpec) *Namespace {
-	r := &Namespace{
-		md:   resource.NewMetadata(NamespaceName, NamespaceType, id, resource.VersionUndefined),
-		spec: spec,
-	}
-
-	r.md.BumpVersion()
-
-	return r
-}
-
-// Metadata implements resource.Resource.
-func (r *Namespace) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *Namespace) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *Namespace) DeepCopy() resource.Resource { //nolint:ireturn
-	return &Namespace{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
-
-// ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (r *Namespace) ResourceDefinition() ResourceDefinitionSpec {
-	return ResourceDefinitionSpec{
-		Type:             NamespaceType,
-		DefaultNamespace: NamespaceName,
-		Aliases:          []resource.Type{"ns"},
-	}
+// DeepCopy generates a deep copy of NamespaceSpec.
+func (n NamespaceSpec) DeepCopy() NamespaceSpec {
+	return n
 }

--- a/pkg/resource/meta/resource_definition.go
+++ b/pkg/resource/meta/resource_definition.go
@@ -6,132 +6,25 @@ package meta
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
-	"unicode"
-
-	pluralize "github.com/gertd/go-pluralize"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta/spec"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 // ResourceDefinitionType is the type of ResourceDefinition.
 const ResourceDefinitionType = resource.Type("ResourceDefinitions.meta.cosi.dev")
 
-// ResourceDefinition provides metadata about namespaces.
-type ResourceDefinition struct {
-	spec ResourceDefinitionSpec
-	md   resource.Metadata
-}
+type (
+	// PrintColumn describes extra columns to print for the resources.
+	PrintColumn = spec.PrintColumn
 
-// PrintColumn describes extra columns to print for the resources.
-type PrintColumn struct {
-	Name     string `yaml:"name"`
-	JSONPath string `yaml:"jsonPath"`
-}
+	// ResourceDefinitionSpec provides ResourceDefinition definition.
+	ResourceDefinitionSpec = spec.ResourceDefinitionSpec
 
-// ResourceDefinitionSpec provides ResourceDefinition definition.
-type ResourceDefinitionSpec struct { //nolint:govet
-	// Canonical type name.
-	Type resource.Type `yaml:"type"`
-	// Displayed human-readable type name.
-	DisplayType string `yaml:"displayType"`
-
-	// Default namespace to look for the resource if no namespace is given.
-	DefaultNamespace resource.Namespace `yaml:"defaultNamespace"`
-
-	// Human-readable aliases.
-	Aliases []resource.Type `yaml:"aliases"`
-	// All aliases for automatic matching.
-	AllAliases []resource.Type `yaml:"allAliases"`
-
-	// Additional columns to print in table output.
-	PrintColumns []PrintColumn `yaml:"printColumns"`
-
-	// Sensitivity indicates how secret resource of this type is.
-	// The empty value represents a non-sensitive resource.
-	Sensitivity Sensitivity `yaml:"sensitivity,omitempty"`
-}
-
-// ID computes id of the resource definition.
-func (spec *ResourceDefinitionSpec) ID() resource.ID {
-	return strings.ToLower(spec.Type)
-}
-
-var (
-	nameRegexp      = regexp.MustCompile(`^[A-Z][A-Za-z0-9-]+$`)
-	suffixRegexp    = regexp.MustCompile(`^[a-z][a-z0-9-]+(\.[a-z][a-z0-9-]+)*$`)
-	pluralizeClient = pluralize.NewClient()
+	// ResourceDefinition provides metadata about namespaces.
+	ResourceDefinition = typed.Resource[ResourceDefinitionSpec, ResourceDefinitionRD]
 )
-
-// Fill the spec while validating any missing items.
-func (spec *ResourceDefinitionSpec) Fill() error {
-	parts := strings.SplitN(spec.Type, ".", 2)
-	if len(parts) == 1 {
-		return fmt.Errorf("missing suffix")
-	}
-
-	name, suffix := parts[0], parts[1]
-
-	if len(name) == 0 {
-		return fmt.Errorf("name is empty")
-	}
-
-	if len(suffix) == 0 {
-		return fmt.Errorf("suffix is empty")
-	}
-
-	if strings.ToLower(name) == name {
-		return fmt.Errorf("name should be in CamelCase")
-	}
-
-	if !nameRegexp.MatchString(name) {
-		return fmt.Errorf("name doesn't match %q", nameRegexp.String())
-	}
-
-	if !suffixRegexp.MatchString(suffix) {
-		return fmt.Errorf("suffix doesn't match %q", suffixRegexp.String())
-	}
-
-	if !pluralizeClient.IsPlural(name) {
-		return fmt.Errorf("name should be plural")
-	}
-
-	spec.DisplayType = pluralizeClient.Singular(name)
-	spec.Aliases = append(spec.Aliases, strings.ToLower(spec.DisplayType))
-
-	spec.AllAliases = append(spec.AllAliases, strings.ToLower(name))
-
-	suffixElements := strings.Split(suffix, ".")
-
-	for i := 1; i < len(suffixElements); i++ {
-		spec.AllAliases = append(spec.AllAliases, strings.Join(append([]string{strings.ToLower(name)}, suffixElements[:i]...), "."))
-	}
-
-	upperLetters := strings.Map(func(ch rune) rune {
-		if unicode.IsUpper(ch) {
-			return ch
-		}
-
-		return -1
-	}, name)
-
-	if len(upperLetters) > 1 {
-		spec.Aliases = append(spec.Aliases, strings.ToLower(upperLetters))
-
-		if !strings.HasSuffix(upperLetters, "S") {
-			spec.Aliases = append(spec.Aliases, strings.ToLower(upperLetters+"s"))
-		}
-	}
-
-	spec.AllAliases = append(spec.AllAliases, spec.Aliases...)
-
-	if _, ok := allSensitivities[spec.Sensitivity]; !ok {
-		return fmt.Errorf("unknown sensitivity %q", spec.Sensitivity)
-	}
-
-	return nil
-}
 
 // NewResourceDefinition initializes a ResourceDefinition resource.
 func NewResourceDefinition(spec ResourceDefinitionSpec) (*ResourceDefinition, error) {
@@ -139,36 +32,17 @@ func NewResourceDefinition(spec ResourceDefinitionSpec) (*ResourceDefinition, er
 		return nil, fmt.Errorf("error validating resource definition %q: %w", spec.Type, err)
 	}
 
-	r := &ResourceDefinition{
-		md:   resource.NewMetadata(NamespaceName, ResourceDefinitionType, spec.ID(), resource.VersionUndefined),
-		spec: spec,
-	}
-
-	r.md.BumpVersion()
-
-	return r, nil
+	return typed.NewResource[ResourceDefinitionSpec, ResourceDefinitionRD](
+		resource.NewMetadata(NamespaceName, ResourceDefinitionType, spec.ID(), resource.VersionUndefined),
+		spec,
+	), nil
 }
 
-// Metadata implements resource.Resource.
-func (r *ResourceDefinition) Metadata() *resource.Metadata {
-	return &r.md
-}
-
-// Spec implements resource.Resource.
-func (r *ResourceDefinition) Spec() interface{} {
-	return r.spec
-}
-
-// DeepCopy implements resource.Resource.
-func (r *ResourceDefinition) DeepCopy() resource.Resource { //nolint:ireturn
-	return &ResourceDefinition{
-		md:   r.md,
-		spec: r.spec,
-	}
-}
+// ResourceDefinitionRD provides auxiliary methods for ResourceDefinition.
+type ResourceDefinitionRD struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (r *ResourceDefinition) ResourceDefinition() ResourceDefinitionSpec {
+func (ResourceDefinitionRD) ResourceDefinition(_ resource.Metadata, _ spec.ResourceDefinitionSpec) ResourceDefinitionSpec {
 	return ResourceDefinitionSpec{
 		Type:             ResourceDefinitionType,
 		DefaultNamespace: NamespaceName,

--- a/pkg/resource/meta/sensitivity.go
+++ b/pkg/resource/meta/sensitivity.go
@@ -4,17 +4,10 @@
 
 package meta
 
-// Sensitivity indicates how secret resource is.
-// The empty value represents a non-sensitive resource.
-type Sensitivity string
+import "github.com/cosi-project/runtime/pkg/resource/meta/spec"
 
 // Sensitivity values.
 const (
-	NonSensitive Sensitivity = ""
-	Sensitive    Sensitivity = "sensitive"
+	NonSensitive = spec.NonSensitive
+	Sensitive    = spec.Sensitive
 )
-
-var allSensitivities = map[Sensitivity]struct{}{
-	NonSensitive: {},
-	Sensitive:    {},
-}

--- a/pkg/resource/meta/spec/resource_definition.go
+++ b/pkg/resource/meta/spec/resource_definition.go
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package spec
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/gertd/go-pluralize"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+)
+
+// ResourceDefinitionSpec provides ResourceDefinition definition.
+type ResourceDefinitionSpec struct { //nolint:govet
+	// Canonical type name.
+	Type resource.Type `yaml:"type"`
+	// Displayed human-readable type name.
+	DisplayType string `yaml:"displayType"`
+
+	// Default namespace to look for the resource if no namespace is given.
+	DefaultNamespace resource.Namespace `yaml:"defaultNamespace"`
+
+	// Human-readable aliases.
+	Aliases []resource.Type `yaml:"aliases"`
+	// All aliases for automatic matching.
+	AllAliases []resource.Type `yaml:"allAliases"`
+
+	// Additional columns to print in table output.
+	PrintColumns []PrintColumn `yaml:"printColumns"`
+
+	// Sensitivity indicates how secret resource of this type is.
+	// The empty value represents a non-sensitive resource.
+	Sensitivity Sensitivity `yaml:"sensitivity,omitempty"`
+}
+
+// ID computes id of the resource definition.
+func (spec *ResourceDefinitionSpec) ID() resource.ID {
+	return strings.ToLower(spec.Type)
+}
+
+// Fill the spec while validating any missing items.
+func (spec *ResourceDefinitionSpec) Fill() error {
+	parts := strings.SplitN(spec.Type, ".", 2)
+	if len(parts) == 1 {
+		return fmt.Errorf("missing suffix")
+	}
+
+	name, suffix := parts[0], parts[1]
+
+	if len(name) == 0 {
+		return fmt.Errorf("name is empty")
+	}
+
+	if len(suffix) == 0 {
+		return fmt.Errorf("suffix is empty")
+	}
+
+	if strings.ToLower(name) == name {
+		return fmt.Errorf("name should be in CamelCase")
+	}
+
+	if !nameRegexp.MatchString(name) {
+		return fmt.Errorf("name doesn't match %q", nameRegexp.String())
+	}
+
+	if !suffixRegexp.MatchString(suffix) {
+		return fmt.Errorf("suffix doesn't match %q", suffixRegexp.String())
+	}
+
+	if !pluralizeClient.IsPlural(name) {
+		return fmt.Errorf("name should be plural")
+	}
+
+	spec.DisplayType = pluralizeClient.Singular(name)
+	spec.Aliases = append(spec.Aliases, strings.ToLower(spec.DisplayType))
+
+	spec.AllAliases = append(spec.AllAliases, strings.ToLower(name))
+
+	suffixElements := strings.Split(suffix, ".")
+
+	for i := 1; i < len(suffixElements); i++ {
+		spec.AllAliases = append(spec.AllAliases, strings.Join(append([]string{strings.ToLower(name)}, suffixElements[:i]...), "."))
+	}
+
+	upperLetters := strings.Map(func(ch rune) rune {
+		if unicode.IsUpper(ch) {
+			return ch
+		}
+
+		return -1
+	}, name)
+
+	if len(upperLetters) > 1 {
+		spec.Aliases = append(spec.Aliases, strings.ToLower(upperLetters))
+
+		if !strings.HasSuffix(upperLetters, "S") {
+			spec.Aliases = append(spec.Aliases, strings.ToLower(upperLetters+"s"))
+		}
+	}
+
+	spec.AllAliases = append(spec.AllAliases, spec.Aliases...)
+
+	if _, ok := allSensitivities[spec.Sensitivity]; !ok {
+		return fmt.Errorf("unknown sensitivity %q", spec.Sensitivity)
+	}
+
+	return nil
+}
+
+// DeepCopy generates a deep copy of ResourceDefinitionSpec.
+func (spec ResourceDefinitionSpec) DeepCopy() ResourceDefinitionSpec {
+	cp := spec
+
+	if spec.Aliases != nil {
+		cp.Aliases = make([]string, len(spec.Aliases))
+		copy(cp.Aliases, spec.Aliases)
+	}
+
+	if spec.AllAliases != nil {
+		cp.AllAliases = make([]string, len(spec.AllAliases))
+		copy(cp.AllAliases, spec.AllAliases)
+	}
+
+	if spec.PrintColumns != nil {
+		cp.PrintColumns = make([]PrintColumn, len(spec.PrintColumns))
+		copy(cp.PrintColumns, spec.PrintColumns)
+	}
+
+	return cp
+}
+
+var (
+	nameRegexp      = regexp.MustCompile(`^[A-Z][A-Za-z0-9-]+$`)
+	suffixRegexp    = regexp.MustCompile(`^[a-z][a-z0-9-]+(\.[a-z][a-z0-9-]+)*$`)
+	pluralizeClient = pluralize.NewClient()
+)
+
+// PrintColumn describes extra columns to print for the resources.
+type PrintColumn struct {
+	Name     string `yaml:"name"`
+	JSONPath string `yaml:"jsonPath"`
+}

--- a/pkg/resource/meta/spec/sensitivity.go
+++ b/pkg/resource/meta/spec/sensitivity.go
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package spec
+
+// Sensitivity indicates how secret resource is.
+// The empty value represents a non-sensitive resource.
+type Sensitivity string
+
+// Sensitivity values.
+const (
+	NonSensitive Sensitivity = ""
+	Sensitive    Sensitivity = "sensitive"
+)
+
+var allSensitivities = map[Sensitivity]struct{}{
+	NonSensitive: {},
+	Sensitive:    {},
+}

--- a/pkg/resource/typed/typed_resource.go
+++ b/pkg/resource/typed/typed_resource.go
@@ -6,7 +6,7 @@ package typed
 
 import (
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/meta/spec"
 )
 
 // DeepCopyable requires a spec to have DeepCopy method which will be used during Resource copy.
@@ -18,7 +18,7 @@ type DeepCopyable[T any] interface {
 // methods. It intantianed only during String and ResourceDefinition calls, so it should never contain any data which
 // survives those calls. Any empty struct{} will do.
 type ResourceDefinition[T any] interface {
-	ResourceDefinition(md resource.Metadata, spec T) meta.ResourceDefinitionSpec
+	ResourceDefinition(md resource.Metadata, spec T) spec.ResourceDefinitionSpec
 }
 
 // Resource provides a generic base implementation for resource.Resource.
@@ -47,8 +47,8 @@ func (t *Resource[T, RD]) DeepCopy() resource.Resource { //nolint:ireturn
 	return &Resource[T, RD]{t.spec.DeepCopy(), t.md}
 }
 
-// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
-func (t *Resource[T, RD]) ResourceDefinition() meta.ResourceDefinitionSpec {
+// ResourceDefinition implements spec.ResourceDefinitionProvider interface.
+func (t *Resource[T, RD]) ResourceDefinition() spec.ResourceDefinitionSpec {
 	var zero RD
 
 	return zero.ResourceDefinition(t.md, t.spec)


### PR DESCRIPTION
Refactor meta.Namespace and meta.ResourceDefinition by implementing them using typed.Resource and moving ResourceDefinitionSpec to a side pkg to prevent cyclic imports.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>