### PR TITLE
chore: migrate from AlekSi/pointer to siderolabs/go-pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ go 1.18
 replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b
 
 require (
-	github.com/AlekSi/pointer v1.1.0
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-memdb v1.3.2
+	github.com/siderolabs/go-pointer v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/go-retry v0.3.1
 	go.uber.org/goleak v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AlekSi/pointer v1.1.0 h1:SSDMPcXD9jSl8FPy9cRzoRaMJtm9g9ggGTxecRUbQoI=
-github.com/AlekSi/pointer v1.1.0/go.mod h1:y7BvfRI3wXPWKXEBhU71nbnIEEZX0QTSB2Bj48UJIZE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -71,6 +69,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/siderolabs/go-pointer v1.0.0 h1:6TshPKep2doDQJAAtHUuHWXbca8ZfyRySjSBT/4GsMU=
+github.com/siderolabs/go-pointer v1.0.0/go.mod h1:HTRFUNYa3R+k0FFKNv11zgkaCLzEkWVzoYZ433P3kHc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AlekSi/pointer"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/siderolabs/go-pointer"
 	"go.uber.org/zap"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -188,7 +188,7 @@ func (adapter *adapter) checkFinalizerAccess(resourceNamespace resource.Namespac
 
 // Get implements controller.Runtime interface.
 func (adapter *adapter) Get(ctx context.Context, resourcePointer resource.Pointer) (resource.Resource, error) { //nolint:ireturn
-	if err := adapter.checkReadAccess(resourcePointer.Namespace(), resourcePointer.Type(), pointer.ToString(resourcePointer.ID())); err != nil {
+	if err := adapter.checkReadAccess(resourcePointer.Namespace(), resourcePointer.Type(), pointer.To(resourcePointer.ID())); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/runtime/dependency/database.go
+++ b/pkg/controller/runtime/dependency/database.go
@@ -7,8 +7,8 @@ package dependency
 import (
 	"fmt"
 
-	"github.com/AlekSi/pointer"
 	"github.com/hashicorp/go-memdb"
+	"github.com/siderolabs/go-pointer"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -327,7 +327,7 @@ func (db *Database) GetControllerInputs(controllerName string) ([]controller.Inp
 		}
 
 		if model.ID != StarID {
-			dep.ID = pointer.ToString(model.ID)
+			dep.ID = pointer.To(model.ID)
 		}
 
 		result = append(result, dep)

--- a/pkg/controller/runtime/dependency/database_test.go
+++ b/pkg/controller/runtime/dependency/database_test.go
@@ -7,7 +7,7 @@ package dependency_test
 import (
 	"testing"
 
-	"github.com/AlekSi/pointer"
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -118,7 +118,7 @@ func (suite *DatabaseSuite) TestControllerDependency() {
 	suite.Require().NoError(suite.db.AddControllerInput("ConfigController", controller.Input{
 		Namespace: "state",
 		Type:      "Machine",
-		ID:        pointer.ToString("system"),
+		ID:        pointer.To("system"),
 		Kind:      controller.InputStrong,
 	}))
 
@@ -139,7 +139,7 @@ func (suite *DatabaseSuite) TestControllerDependency() {
 	ctrls, err := suite.db.GetDependentControllers(controller.Input{
 		Namespace: "user",
 		Type:      "Config",
-		ID:        pointer.ToString("config"),
+		ID:        pointer.To("config"),
 	})
 	suite.Require().NoError(err)
 	suite.Assert().Equal([]string{"ConfigController"}, ctrls)
@@ -161,7 +161,7 @@ func (suite *DatabaseSuite) TestControllerDependency() {
 	ctrls, err = suite.db.GetDependentControllers(controller.Input{
 		Namespace: "state",
 		Type:      "Machine",
-		ID:        pointer.ToString("node"),
+		ID:        pointer.To("node"),
 	})
 	suite.Require().NoError(err)
 	suite.Assert().Empty(ctrls)
@@ -169,7 +169,7 @@ func (suite *DatabaseSuite) TestControllerDependency() {
 	ctrls, err = suite.db.GetDependentControllers(controller.Input{
 		Namespace: "state",
 		Type:      "Machine",
-		ID:        pointer.ToString("system"),
+		ID:        pointer.To("system"),
 	})
 	suite.Require().NoError(err)
 	suite.Assert().Equal([]string{"ConfigController"}, ctrls)
@@ -184,7 +184,7 @@ func (suite *DatabaseSuite) TestControllerDependency() {
 	suite.Require().NoError(suite.db.DeleteControllerInput("ConfigController", controller.Input{
 		Namespace: "state",
 		Type:      "Machine",
-		ID:        pointer.ToString("system"),
+		ID:        pointer.To("system"),
 	}))
 
 	ctrls, err = suite.db.GetDependentControllers(controller.Input{
@@ -221,7 +221,7 @@ func (suite *DatabaseSuite) TestExport() {
 		Namespace: "user",
 		Type:      "Config",
 		Kind:      controller.InputWeak,
-		ID:        pointer.ToString("config"),
+		ID:        pointer.To("config"),
 	}))
 
 	suite.Require().NoError(suite.db.AddControllerInput("ControllerTable", controller.Input{

--- a/pkg/controller/runtime/dependency/dependency_test.go
+++ b/pkg/controller/runtime/dependency/dependency_test.go
@@ -7,7 +7,7 @@ package dependency_test
 import (
 	"testing"
 
-	"github.com/AlekSi/pointer"
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -27,13 +27,13 @@ func TestLess(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: false,
@@ -43,13 +43,13 @@ func TestLess(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("jd"),
+				ID:        pointer.To("jd"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: true,
@@ -94,13 +94,13 @@ func TestEqual(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: true,
@@ -110,13 +110,13 @@ func TestEqual(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("jd"),
+				ID:        pointer.To("jd"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: false,
@@ -126,7 +126,7 @@ func TestEqual(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
@@ -174,13 +174,13 @@ func TestEqual(t *testing.T) {
 			A: controller.Input{
 				Namespace: "user",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: false,
@@ -209,13 +209,13 @@ func TestEqualKeys(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: true,
@@ -225,13 +225,13 @@ func TestEqualKeys(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputWeak,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: true,
@@ -241,13 +241,13 @@ func TestEqualKeys(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("jd"),
+				ID:        pointer.To("jd"),
 				Kind:      controller.InputStrong,
 			},
 			Expected: false,
@@ -257,7 +257,7 @@ func TestEqualKeys(t *testing.T) {
 			A: controller.Input{
 				Namespace: "default",
 				Type:      "Config",
-				ID:        pointer.ToString("id"),
+				ID:        pointer.To("id"),
 				Kind:      controller.InputStrong,
 			},
 			B: controller.Input{

--- a/pkg/controller/runtime/runtime.go
+++ b/pkg/controller/runtime/runtime.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/AlekSi/pointer"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/siderolabs/go-pointer"
 	"go.uber.org/zap"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -234,7 +234,7 @@ func (runtime *Runtime) processWatched() {
 		controllers, err := runtime.depDB.GetDependentControllers(controller.Input{
 			Namespace: md.Namespace(),
 			Type:      md.Type(),
-			ID:        pointer.ToString(md.ID()),
+			ID:        pointer.To(md.ID()),
 		})
 		if err != nil {
 			// TODO: no way to handle it here

--- a/pkg/resource/version.go
+++ b/pkg/resource/version.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/AlekSi/pointer"
+	"github.com/siderolabs/go-pointer"
 )
 
 // Version of a resource.
@@ -55,6 +55,6 @@ func ParseVersion(ver string) (Version, error) {
 	}
 
 	return Version{
-		uint64: pointer.ToUint64(uint64(intVersion)),
+		uint64: pointer.To(uint64(intVersion)),
 	}, nil
 }

--- a/pkg/state/protobuf/client/client.go
+++ b/pkg/state/protobuf/client/client.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/AlekSi/pointer"
+	"github.com/siderolabs/go-pointer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -182,7 +182,7 @@ func (adapter *Adapter) Update(ctx context.Context, curVersion resource.Version,
 	var expectedPhase *string
 
 	if opts.ExpectedPhase != nil {
-		expectedPhase = pointer.ToString(opts.ExpectedPhase.String())
+		expectedPhase = pointer.To(opts.ExpectedPhase.String())
 	}
 
 	_, err = adapter.client.Update(ctx, &v1alpha1.UpdateRequest{
@@ -264,7 +264,7 @@ func (adapter *Adapter) Watch(ctx context.Context, resourcePointer resource.Poin
 	cli, err := adapter.client.Watch(ctx, &v1alpha1.WatchRequest{
 		Namespace: resourcePointer.Namespace(),
 		Type:      resourcePointer.Type(),
-		Id:        pointer.ToString(resourcePointer.ID()),
+		Id:        pointer.To(resourcePointer.ID()),
 		Options: &v1alpha1.WatchOptions{
 			TailEvents: int32(opts.TailEvents),
 		},


### PR DESCRIPTION
Now that we have generics and require Go 1.18 - redo pointer.* functions as two generic functions.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>