### PR TITLE
feat: implement generic UnmarshalProto on the resource

### DIFF
--- a/pkg/resource/protobuf/resource.go
+++ b/pkg/resource/protobuf/resource.go
@@ -100,6 +100,11 @@ type ProtoMarshaler interface {
 	MarshalProto() ([]byte, error)
 }
 
+// ProtoUnmarshaler is an interface which should be implemented by Resource spec to support conversion from protobuf.Resource.
+type ProtoUnmarshaler interface {
+	UnmarshalProto([]byte) error
+}
+
 // FromResource converts a resource which supports spec protobuf marshaling to protobuf.Resource.
 func FromResource(r resource.Resource) (*Resource, error) {
 	if protoR, ok := r.(*Resource); ok {


### PR DESCRIPTION
This implements a generic `UnmarshalProto` for `typed.Resource`.

There might be a better way to do protobuf marshaling with generics, but
this is a stopgap for now to allow conversion of the only resource in
Talos right now which implements conversion to protobufs.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>