### PR TITLE
feat: implement a generic `proto.Message` spec implementation

### DIFF
--- a/pkg/resource/protobuf/spec.go
+++ b/pkg/resource/protobuf/spec.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package protobuf
+
+import "google.golang.org/protobuf/proto"
+
+// Spec should be proto.Message and pointer.
+type Spec[T any] interface {
+	proto.Message
+	*T
+}
+
+// ResourceSpec wraps proto.Message structures and adds DeepCopy and marshaling methods.
+// T is a protobuf generated structure.
+// S is a pointer to T.
+// Example usage:
+// type WrappedSpec = ResourceSpec[ProtoSpec, *ProtoSpec].
+type ResourceSpec[T any, S Spec[T]] struct {
+	Value S
+}
+
+// DeepCopy creates a copy of the wrapped proto.Message.
+func (spec ResourceSpec[T, S]) DeepCopy() ResourceSpec[T, S] {
+	return ResourceSpec[T, S]{
+		Value: proto.Clone(spec.Value).(S), //nolint:forcetypeassert
+	}
+}
+
+// MarshalProto implements ProtoMarshaler.
+func (spec ResourceSpec[T, S]) MarshalProto() ([]byte, error) {
+	return proto.Marshal(spec.Value)
+}
+
+// UnmarshalProto implements protobuf.ResourceUnmarshaler.
+func (spec *ResourceSpec[T, S]) UnmarshalProto(protoBytes []byte) error {
+	spec.Value = new(T)
+
+	return proto.Unmarshal(protoBytes, spec.Value)
+}
+
+// NewResourceSpec creates new ResourceSpec[T, S].
+// T is a protobuf generated structure.
+// S is a pointer to T.
+func NewResourceSpec[T any, S Spec[T]](value S) ResourceSpec[T, S] {
+	return ResourceSpec[T, S]{
+		Value: value,
+	}
+}

--- a/pkg/resource/protobuf/spec_test.go
+++ b/pkg/resource/protobuf/spec_test.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package protobuf_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/cosi-project/runtime/api/v1alpha1"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+)
+
+type testSpec = protobuf.ResourceSpec[v1alpha1.Metadata, *v1alpha1.Metadata]
+
+func TestResourceSpec(t *testing.T) {
+	spec := protobuf.NewResourceSpec(&v1alpha1.Metadata{
+		Version: "v0.1.0",
+	})
+
+	data, err := spec.MarshalProto()
+	require.NoError(t, err)
+
+	specDecoded := testSpec{}
+	err = specDecoded.UnmarshalProto(data)
+	require.NoError(t, err)
+
+	require.True(t, proto.Equal(spec.Value, specDecoded.Value))
+}


### PR DESCRIPTION
The wrapper implements `DeepCopy`, `MarshalProto` and `UnmarshalProto`
methods and allows using protobuf generated structs in `typed` resources
which require specs to support passing by copy.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>