### PR TITLE
chore: provide an interface for getting wrapped protobuf value

### DIFF
--- a/pkg/resource/protobuf/spec.go
+++ b/pkg/resource/protobuf/spec.go
@@ -12,6 +12,13 @@ type Spec[T any] interface {
 	*T
 }
 
+// ResourceSpecWrapper defines interface for the protobuf resource wrapped by a generic structure.
+type ResourceSpecWrapper interface {
+	ProtoMarshaler
+	ProtoUnmarshaler
+	GetValue() proto.Message
+}
+
 // ResourceSpec wraps proto.Message structures and adds DeepCopy and marshaling methods.
 // T is a protobuf generated structure.
 // S is a pointer to T.
@@ -38,6 +45,11 @@ func (spec *ResourceSpec[T, S]) UnmarshalProto(protoBytes []byte) error {
 	spec.Value = new(T)
 
 	return proto.Unmarshal(protoBytes, spec.Value)
+}
+
+// GetValue returns wrapped protobuf object.
+func (spec *ResourceSpec[T, S]) GetValue() proto.Message { //nolint:ireturn
+	return spec.Value
 }
 
 // NewResourceSpec creates new ResourceSpec[T, S].


### PR DESCRIPTION
This is required for Theila internal logic as it relies on dumping
protobuf specs as `map[string]interface{}` and sending it to the
javascript side.

With the change it will be possible to extract value from the wrapper
without knowing an exact type.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>