### PR TITLE
chore: use value receiver in `GetValue` method of the `ResourceSpec`

### DIFF
--- a/pkg/resource/protobuf/spec.go
+++ b/pkg/resource/protobuf/spec.go
@@ -41,7 +41,7 @@ func (spec *ResourceSpec[T, S]) UnmarshalProto(protoBytes []byte) error {
 }
 
 // GetValue returns wrapped protobuf object.
-func (spec *ResourceSpec[T, S]) GetValue() proto.Message { //nolint:ireturn
+func (spec ResourceSpec[T, S]) GetValue() proto.Message { //nolint:ireturn
 	return spec.Value
 }
 


### PR DESCRIPTION
It's copied everywhere, so we pointer receiver will fail this check:

```go
type Getter interface {
  GetValue() proto.Message
}

if _, ok := wrapper.(Getter); ok {
...
}
```

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>