### PR TITLE
feat: expose resource registry resource creation methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-04-12T21:42:27Z by kres 4975f30.
+# Generated on 2022-05-25T15:41:00Z by kres latest.
 
 # options for analysis running
 run:
@@ -124,6 +124,7 @@ linters:
   disable-all: false
   fast: false
   disable:
+    - exhaustruct
     - exhaustivestruct
     - forbidigo
     - funlen

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1,5 +1,5 @@
 ---
-kind: golang.Protobuf
+kind: golang.Generate
 spec:
   experimentalFlags:
     - --experimental_allow_proto3_optional

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-04-22T17:30:48Z by kres 685be7b-dirty.
+# Generated on 2022-05-25T15:53:03Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -11,13 +11,13 @@ FROM ghcr.io/siderolabs/ca-certificates:v1.0.0 AS image-ca-certificates
 FROM ghcr.io/siderolabs/fhs:v1.0.0 AS image-fhs
 
 # runs markdownlint
-FROM node:14.8.0-alpine AS lint-markdown
-RUN npm i -g markdownlint-cli@0.23.2
-RUN npm i sentences-per-line@0.2.1
+FROM node:18.2.0-alpine AS lint-markdown
 WORKDIR /src
+RUN npm i -g markdownlint-cli@0.31.1
+RUN npm i sentences-per-line@0.2.1
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
-RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
+RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules node_modules/sentences-per-line/index.js .
 
 # collects proto specs
 FROM scratch AS proto-specs
@@ -34,7 +34,8 @@ FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.45.2
+ARG GOLANGCILINT_VERSION
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCILINT_VERSION}/install.sh | bash -s -- -b /bin ${GOLANGCILINT_VERSION}
 ARG GOFUMPT_VERSION
 RUN go install mvdan.cc/gofumpt@${GOFUMPT_VERSION} \
 	&& mv /go/bin/gofumpt /bin/gofumpt
@@ -53,6 +54,9 @@ RUN mv /go/bin/protoc-gen-grpc-gateway /bin
 ARG VTPROTOBUF_VERSION
 RUN go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v${VTPROTOBUF_VERSION}
 RUN mv /go/bin/protoc-gen-go-vtproto /bin
+ARG DEEPCOPY_VERSION
+RUN go install github.com/siderolabs/deep-copy@${DEEPCOPY_VERSION} \
+	&& mv /go/bin/deep-copy /bin/deep-copy
 
 # tools and sources
 FROM tools AS base

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-04-22T17:29:34Z by kres 685be7b-dirty.
+# Generated on 2022-05-25T15:53:03Z by kres latest.
 
 # common variables
 
@@ -11,6 +11,7 @@ ARTIFACTS := _out
 REGISTRY ?= ghcr.io
 USERNAME ?= cosi-project
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
+GOLANGCILINT_VERSION ?= v1.46.2
 GOFUMPT_VERSION ?= v0.3.1
 GO_VERSION ?= 1.18
 GOIMPORTS_VERSION ?= v0.1.10
@@ -18,8 +19,10 @@ PROTOBUF_GO_VERSION ?= 1.28.0
 GRPC_GO_VERSION ?= 1.2.0
 GRPC_GATEWAY_VERSION ?= 2.10.0
 VTPROTOBUF_VERSION ?= 0.3.0
+DEEPCOPY_VERSION ?= v0.5.5
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
+CONFORMANCE_IMAGE ?= ghcr.io/siderolabs/conform:latest
 
 # docker build settings
 
@@ -37,12 +40,14 @@ COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
+COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION=$(GOLANGCILINT_VERSION)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
 COMMON_ARGS += --build-arg=GOIMPORTS_VERSION=$(GOIMPORTS_VERSION)
 COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION=$(PROTOBUF_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION=$(VTPROTOBUF_VERSION)
+COMMON_ARGS += --build-arg=DEEPCOPY_VERSION=$(DEEPCOPY_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
 TOOLCHAIN ?= docker.io/golang:1.18-alpine
 
@@ -161,4 +166,9 @@ help:  ## This help menu.
 release-notes:
 	mkdir -p $(ARTIFACTS)
 	@ARTIFACTS=$(ARTIFACTS) ./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
+
+.PHONY: conformance
+conformance:
+	@docker pull $(CONFORMANCE_IMAGE)
+	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
 

--- a/pkg/controller/protobuf/client/client.go
+++ b/pkg/controller/protobuf/client/client.go
@@ -250,7 +250,9 @@ func (ctrlAdapter *controllerAdapter) run(ctx context.Context) {
 	}
 }
 
-func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.Logger) (err error) {
+func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.Logger) error {
+	var err error
+
 	defer func() {
 		if err != nil && (errors.Is(err, context.Canceled) || status.Code(errors.Unwrap(err)) == codes.Canceled) {
 			err = nil
@@ -273,7 +275,7 @@ func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.L
 
 	err = ctrlAdapter.controller.Run(ctx, ctrlAdapter, logger)
 
-	return
+	return err
 }
 
 func (ctrlAdapter *controllerAdapter) establishEventChannel() {

--- a/pkg/controller/protobuf/protobuf_test.go
+++ b/pkg/controller/protobuf/protobuf_test.go
@@ -73,7 +73,7 @@ func TestProtobufConformance(t *testing.T) {
 			suite.grpcServer.Serve(l) //nolint:errcheck
 		}()
 
-		suite.grpcConn, err = grpc.Dial("unix://"+suite.sock.Name(), grpc.WithInsecure())
+		suite.grpcConn, err = grpc.Dial("unix://"+suite.sock.Name(), grpc.WithInsecure()) //nolint:staticcheck
 		require.NoError(t, err)
 
 		stateClient := v1alpha1.NewStateClient(suite.grpcConn)

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -383,7 +383,9 @@ func (adapter *adapter) run(ctx context.Context) {
 	}
 }
 
-func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) (err error) {
+func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) error {
+	var err error
+
 	defer func() {
 		if err != nil && errors.Is(err, context.Canceled) {
 			err = nil
@@ -406,5 +408,5 @@ func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) (err er
 
 	err = adapter.ctrl.Run(ctx, adapter, logger)
 
-	return
+	return err
 }

--- a/pkg/resource/finalizer.go
+++ b/pkg/resource/finalizer.go
@@ -13,7 +13,7 @@ type Finalizer = string
 type Finalizers []Finalizer
 
 // Add a (unique) Finalizer to the set.
-func (fins *Finalizers) Add(fin Finalizer) (added bool) {
+func (fins *Finalizers) Add(fin Finalizer) bool {
 	*fins = append(Finalizers(nil), *fins...)
 
 	for _, f := range *fins {
@@ -28,20 +28,18 @@ func (fins *Finalizers) Add(fin Finalizer) (added bool) {
 }
 
 // Remove a (unique) Finalizer from the set.
-func (fins *Finalizers) Remove(fin Finalizer) (removed bool) {
+func (fins *Finalizers) Remove(fin Finalizer) bool {
 	*fins = append(Finalizers(nil), *fins...)
 
 	for i, f := range *fins {
 		if f == fin {
-			removed = true
-
 			*fins = append((*fins)[:i], (*fins)[i+1:]...)
 
-			return
+			return true
 		}
 	}
 
-	return
+	return false
 }
 
 // Empty returns true if list of finalizers is empty.

--- a/pkg/resource/meta/spec/resource_definition.go
+++ b/pkg/resource/meta/spec/resource_definition.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// Package spec contains resource specs for the meta resources.
 package spec
 
 import (

--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -125,7 +125,7 @@ func (p *protoMd) GetType() string {
 	return "type"
 }
 
-//nolint:golint,revive
+//nolint:golint,revive,stylecheck
 func (p *protoMd) GetId() string {
 	return "aaa"
 }

--- a/pkg/resource/typed/typed_resource.go
+++ b/pkg/resource/typed/typed_resource.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// Package typed generic based resource definition.
 package typed
 
 import (

--- a/pkg/state/protobuf/protobuf_test.go
+++ b/pkg/state/protobuf/protobuf_test.go
@@ -45,7 +45,7 @@ func TestProtobufConformance(t *testing.T) {
 
 	defer grpcServer.Stop()
 
-	grpcConn, err := grpc.Dial("unix://"+sock.Name(), grpc.WithInsecure())
+	grpcConn, err := grpc.Dial("unix://"+sock.Name(), grpc.WithInsecure()) //nolint:staticcheck
 	require.NoError(t, err)
 
 	defer grpcConn.Close() //nolint:errcheck


### PR DESCRIPTION
Directly provide a method to create a resource instance from a registered
resource type.

Then it will be possible to decode the resource manually.
Also rerun Kres and fix all linter issues.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>