### PR TITLE
fix: correctly compare resources when specs are embedded proto structs

### DIFF
--- a/pkg/resource/protobuf/spec.go
+++ b/pkg/resource/protobuf/spec.go
@@ -45,6 +45,16 @@ func (spec ResourceSpec[T, S]) GetValue() proto.Message { //nolint:ireturn
 	return spec.Value
 }
 
+// Equal implements spec equality check.
+func (spec ResourceSpec[T, S]) Equal(other interface{}) bool {
+	otherSpec, ok := other.(ResourceSpec[T, S])
+	if !ok {
+		return false
+	}
+
+	return proto.Equal(spec.Value, otherSpec.Value)
+}
+
 // NewResourceSpec creates new ResourceSpec[T, S].
 // T is a protobuf generated structure.
 // S is a pointer to T.

--- a/pkg/resource/protobuf/spec_test.go
+++ b/pkg/resource/protobuf/spec_test.go
@@ -11,12 +11,17 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/cosi-project/runtime/api/v1alpha1"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 )
 
 type testSpec = protobuf.ResourceSpec[v1alpha1.Metadata, *v1alpha1.Metadata]
 
 func TestResourceSpec(t *testing.T) {
+	t.Parallel()
+
 	spec := protobuf.NewResourceSpec(&v1alpha1.Metadata{
 		Version: "v0.1.0",
 	})
@@ -29,4 +34,53 @@ func TestResourceSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, proto.Equal(spec.Value, specDecoded.Value))
+}
+
+type testResource = typed.Resource[testSpec, testRD]
+
+type testRD struct{} //nolint:unused
+
+//nolint:unused
+func (testRD) ResourceDefinition(md resource.Metadata, spec testSpec) meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type: "testResource",
+	}
+}
+
+func TestResourceEquality(t *testing.T) {
+	t.Parallel()
+
+	r1 := typed.NewResource[testSpec, testRD](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
+		Version: "v0.1.0",
+	}))
+
+	r2 := typed.NewResource[testSpec, testRD](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
+		Version: "v0.1.0",
+	}))
+
+	// two manually created resources should be equal
+	require.True(t, resource.Equal(r1, r2))
+
+	// pass r1 through marshal/unmarshal stage, and make sure it's still equal to itself
+	protoR, err := protobuf.FromResource(r1)
+	require.NoError(t, err)
+
+	pR, err := protoR.Marshal()
+	require.NoError(t, err)
+
+	protoR, err = protobuf.Unmarshal(pR)
+	require.NoError(t, err)
+
+	r3, err := protobuf.UnmarshalResource(protoR)
+	require.NoError(t, err)
+
+	// unmarshaling fills in some private fields in protobuf Go struct which should be ignored
+	// on equality check
+	require.True(t, resource.Equal(r1, r3))
+}
+
+func init() {
+	if err := protobuf.RegisterResource("testResource", &testResource{}); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -45,7 +45,15 @@ func Equal(r1, r2 Resource) bool {
 		return false
 	}
 
-	return reflect.DeepEqual(r1.Spec(), r2.Spec())
+	spec1, spec2 := r1.Spec(), r2.Spec()
+
+	if equality, ok := spec1.(interface {
+		Equal(interface{}) bool
+	}); ok {
+		return equality.Equal(spec2)
+	}
+
+	return reflect.DeepEqual(spec1, spec2)
 }
 
 // MarshalYAML marshals resource to YAML definition.


### PR DESCRIPTION
When resource spec is a protobuf-generated struct, resource.Equal was
working incorrectly as proto types can't be compared correctly with
reflect.DeepEqual.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>