### PR TITLE
chore: add typed wrappers around State, Reader and Writer

### DIFF
--- a/pkg/safe/reader.go
+++ b/pkg/safe/reader.go
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package safe provides a safe wrappers around the cosi runtime.
+package safe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// ReaderGet is a type safe wrapper around reader.Get.
+func ReaderGet[T resource.Resource](ctx context.Context, rdr controller.Reader, ptr resource.Pointer) (T, error) { //nolint:ireturn
+	got, err := rdr.Get(ctx, ptr)
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	result, ok := got.(T)
+	if !ok {
+		var zero T
+
+		return zero, fmt.Errorf("type mismatch: expected %T, got %T", result, got)
+	}
+
+	return result, nil
+}
+
+// ReaderList is a type safe wrapper around Reader.List.
+func ReaderList[T resource.Resource](ctx context.Context, rdr controller.Reader, kind resource.Kind) (List[T], error) {
+	got, err := rdr.List(ctx, kind)
+	if err != nil {
+		var zero List[T]
+
+		return zero, err
+	}
+
+	if len(got.Items) == 0 {
+		var zero List[T]
+
+		return zero, nil
+	}
+
+	// Early assertion to make sure we don't have a type mismatch.
+	if _, ok := got.Items[0].(T); !ok {
+		var zero List[T]
+
+		return zero, fmt.Errorf("type mismatch on the first element: expected %T, got %T", got.Items[0], got)
+	}
+
+	return NewList[T](got), nil
+}
+
+// ReaderWatchFor is a type safe wrapper around Reader.WatchFor.
+func ReaderWatchFor[T resource.Resource](ctx context.Context, rdr controller.Reader, ptr resource.Pointer, conds ...state.WatchForConditionFunc) (T, error) { //nolint:ireturn
+	got, err := rdr.WatchFor(ctx, ptr, conds...)
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	result, ok := got.(T)
+	if !ok {
+		var zero T
+
+		return zero, fmt.Errorf("type mismatch: expected %T, got %T", result, got)
+	}
+
+	return result, nil
+}
+
+// ReaderWatchForResource is a type safe wrapper around Reader.WatchFor which accepts typed resource.Resource and gets the metadata from it.
+func ReaderWatchForResource[T resource.Resource](ctx context.Context, rdr controller.Reader, r T, conds ...state.WatchForConditionFunc) (T, error) { //nolint:ireturn
+	return ReaderWatchFor[T](ctx, rdr, r.Metadata(), conds...)
+}

--- a/pkg/safe/state.go
+++ b/pkg/safe/state.go
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package safe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// StateGet is a type safe wrapper around state.Get.
+func StateGet[T resource.Resource](ctx context.Context, st state.State, ptr resource.Pointer, options ...state.GetOption) (T, error) { //nolint:ireturn
+	got, err := st.Get(ctx, ptr, options...)
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	result, ok := got.(T)
+	if !ok {
+		var zero T
+
+		return zero, fmt.Errorf("type mismatch: expected %T, got %T", result, got)
+	}
+
+	return result, nil
+}
+
+// StateGetResource is a type safe wrapper around state.Get which accepts typed resource.Resource and gets the metadata from it.
+func StateGetResource[T resource.Resource](ctx context.Context, st state.State, r T, options ...state.GetOption) (T, error) { //nolint:ireturn
+	return StateGet[T](ctx, st, r.Metadata(), options...)
+}
+
+// StateUpdateWithConflicts is a type safe wrapper around state.UpdateWithConflicts.
+func StateUpdateWithConflicts[T resource.Resource](ctx context.Context, st state.State, ptr resource.Pointer, updateFn func(T) error, options ...state.UpdateOption) (T, error) { //nolint:ireturn
+	got, err := st.UpdateWithConflicts(ctx, ptr, func(r resource.Resource) error {
+		arg, ok := r.(T)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected %T, got %T", arg, r)
+		}
+
+		return updateFn(arg)
+	}, options...)
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	result, ok := got.(T)
+	if !ok {
+		var zero T
+
+		return zero, fmt.Errorf("type mismatch: expected %T, got %T", result, got)
+	}
+
+	return result, nil
+}
+
+// StateList is a type safe wrapper around state.List.
+func StateList[T resource.Resource](ctx context.Context, st state.State, ptr resource.Pointer, options ...state.ListOption) (List[T], error) {
+	got, err := st.List(ctx, ptr, options...)
+	if err != nil {
+		var zero List[T]
+
+		return zero, err
+	}
+
+	if len(got.Items) == 0 {
+		var zero List[T]
+
+		return zero, nil
+	}
+
+	// Early assertion to make sure we don't have a type mismatch.
+	if _, ok := got.Items[0].(T); !ok {
+		var zero List[T]
+
+		return zero, fmt.Errorf("type mismatch on the first element: expected %T, got %T", got.Items[0], got)
+	}
+
+	return NewList[T](got), nil
+}
+
+// List is a type safe wrapper around resource.List.
+type List[T any] struct {
+	list resource.List
+}
+
+// NewList creates a new List.
+func NewList[T any](list resource.List) List[T] {
+	return List[T]{list}
+}
+
+// Get returns the item at the given index.
+func (l *List[T]) Get(index int) T { //nolint:ireturn
+	return l.list.Items[index].(T) //nolint:forcetypeassert
+}
+
+// Len returns the number of items in the list.
+func (l *List[T]) Len() int {
+	return len(l.list.Items)
+}
+
+// ListIterator is a generic iterator over resource.Resource slice.
+type ListIterator[T any] struct {
+	list List[T]
+	pos  int
+}
+
+// IteratorFromList returns a new iterator over the given list.
+func IteratorFromList[T any](list List[T]) ListIterator[T] {
+	return ListIterator[T]{pos: 0, list: list}
+}
+
+// Next returns the next element of the iterator.
+func (it *ListIterator[T]) Next() bool { //nolint:revive
+	if it.pos >= it.list.Len() {
+		return false
+	}
+
+	it.pos++
+
+	return true
+}
+
+// Value returns the current element of the iterator.
+func (it *ListIterator[T]) Value() T { //nolint:ireturn,revive
+	return it.list.Get(it.pos - 1)
+}

--- a/pkg/safe/writer.go
+++ b/pkg/safe/writer.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package safe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+)
+
+// WriterModify is a type safe wrapper around writer.Modify.
+func WriterModify[T resource.Resource](ctx context.Context, writer controller.Writer, r T, fn func(T) error) error {
+	return writer.Modify(ctx, r, func(r resource.Resource) error {
+		arg, ok := r.(T)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected %T, got %T", arg, r)
+		}
+
+		return fn(arg)
+	})
+}

--- a/pkg/state/conformance/state.go
+++ b/pkg/state/conformance/state.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 )
 
@@ -358,10 +359,8 @@ func (suite *StateSuite) TestConcurrentFinalizers() {
 
 	suite.Assert().NoError(eg.Wait())
 
-	pathRes, err := suite.State.Get(ctx, path.Metadata())
+	path, err := safe.StateGetResource(ctx, suite.State, path)
 	suite.Require().NoError(err)
-
-	path = pathRes.(*PathResource) //nolint:errcheck,forcetypeassert
 
 	finalizers := path.Metadata().Finalizers()
 	sort.Strings(*finalizers)
@@ -619,10 +618,8 @@ func (suite *StateSuite) TestUpdate() {
 	_, err = suite.State.Teardown(ctx, path1.Metadata())
 	suite.Require().NoError(err)
 
-	r, err := suite.State.Get(ctx, path1.Metadata())
+	path1, err = safe.StateGetResource(ctx, suite.State, path1)
 	suite.Require().NoError(err)
-
-	path1 = r.(*PathResource) //nolint:errcheck,forcetypeassert
 
 	curVersion = path1.Metadata().Version()
 	path1.Metadata().BumpVersion()


### PR DESCRIPTION
Add typed wrappers around cosi State, Reader and Writer methods and use them.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>