### PR TITLE
fix: match `WithoutLabel` when there are no labels

### DIFF
--- a/pkg/resource/labels.go
+++ b/pkg/resource/labels.go
@@ -100,7 +100,7 @@ func (labels Labels) Empty() bool {
 // Matches if labels match the LabelTerm.
 func (labels Labels) Matches(term LabelTerm) bool {
 	if labels.m == nil {
-		return false
+		return term.Op == LabelOpNotExists
 	}
 
 	switch term.Op {

--- a/pkg/resource/labels_test.go
+++ b/pkg/resource/labels_test.go
@@ -57,4 +57,28 @@ func TestLabels(t *testing.T) {
 
 	_, ok = labels.Get("a")
 	assert.True(t, ok)
+
+	var termTests resource.Labels
+
+	assert.True(t, termTests.Matches(resource.LabelTerm{
+		Key: "nope",
+		Op:  resource.LabelOpNotExists,
+	}))
+
+	assert.False(t, termTests.Matches(resource.LabelTerm{
+		Key: "nope",
+		Op:  resource.LabelOpExists,
+	}))
+
+	termTests.Set("yes", "")
+
+	assert.True(t, termTests.Matches(resource.LabelTerm{
+		Key: "yes",
+		Op:  resource.LabelOpExists,
+	}))
+
+	assert.False(t, termTests.Matches(resource.LabelTerm{
+		Key: "yes",
+		Op:  resource.LabelOpNotExists,
+	}))
 }


### PR DESCRIPTION
The condition was incorrect in the `labels.Match` function and we had no
test for it. Should be good now.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>