### PR TITLE
refactor: make state.State satisfy controller.Reader interface

### DIFF
--- a/pkg/controller/protobuf/client/client.go
+++ b/pkg/controller/protobuf/client/client.go
@@ -349,7 +349,7 @@ func (ctrlAdapter *controllerAdapter) UpdateInputs(inputs []controller.Input) er
 	return err
 }
 
-func (ctrlAdapter *controllerAdapter) Get(ctx context.Context, resourcePointer resource.Pointer) (resource.Resource, error) { //nolint:ireturn
+func (ctrlAdapter *controllerAdapter) Get(ctx context.Context, resourcePointer resource.Pointer, opts ...state.GetOption) (resource.Resource, error) { //nolint:ireturn
 	resp, err := ctrlAdapter.adapter.client.Get(ctx, &v1alpha1.RuntimeGetRequest{
 		ControllerToken: ctrlAdapter.token,
 

--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -73,8 +73,10 @@ type Output struct {
 }
 
 // Reader provides read-only access to the state.
+//
+// state.State also satisfies this interface.
 type Reader interface {
-	Get(context.Context, resource.Pointer) (resource.Resource, error)
+	Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
 	List(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
 	WatchFor(context.Context, resource.Pointer, ...state.WatchForConditionFunc) (resource.Resource, error)
 }

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -187,12 +187,12 @@ func (adapter *adapter) checkFinalizerAccess(resourceNamespace resource.Namespac
 }
 
 // Get implements controller.Runtime interface.
-func (adapter *adapter) Get(ctx context.Context, resourcePointer resource.Pointer) (resource.Resource, error) { //nolint:ireturn
+func (adapter *adapter) Get(ctx context.Context, resourcePointer resource.Pointer, opts ...state.GetOption) (resource.Resource, error) { //nolint:ireturn
 	if err := adapter.checkReadAccess(resourcePointer.Namespace(), resourcePointer.Type(), pointer.To(resourcePointer.ID())); err != nil {
 		return nil, err
 	}
 
-	return adapter.runtime.state.Get(ctx, resourcePointer)
+	return adapter.runtime.state.Get(ctx, resourcePointer, opts...)
 }
 
 // List implements controller.Runtime interface.

--- a/pkg/controller/runtime_test.go
+++ b/pkg/controller/runtime_test.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+)
+
+func TestInterface(t *testing.T) {
+	t.Parallel()
+
+	assert.Implements(t, (*controller.Reader)(nil), state.WrapCore(&inmem.State{}))
+}


### PR DESCRIPTION
Now state.State might be passed in when controller.Reader is required.

There are no GetOptions now, so it's no-op and non-breaking change.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>