### PR TITLE
fix: inline YAML protobuf value

### DIFF
--- a/pkg/resource/protobuf/spec.go
+++ b/pkg/resource/protobuf/spec.go
@@ -22,7 +22,7 @@ type Spec[T any] interface {
 // Example usage:
 // type WrappedSpec = ResourceSpec[ProtoSpec, *ProtoSpec].
 type ResourceSpec[T any, S Spec[T]] struct {
-	Value S
+	Value S `yaml:",inline"`
 }
 
 // DeepCopy creates a copy of the wrapped proto.Message.


### PR DESCRIPTION
This fixes YAML marshalling for resources with protobuf spec:

```yaml
spec:
  value:
    foo: bar
```

becomes

```yaml
spec:
  foo: bar
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>