### PR TITLE
chore: use the merged proto COSI spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-05-25T15:41:00Z by kres latest.
+# Generated on 2022-06-28T16:24:13Z by kres ba905fc-dirty.
 
 # options for analysis running
 run:
@@ -135,6 +135,7 @@ linters:
     - goerr113
     - gomnd
     - gomoddirectives
+    - ireturn
     - nestif
     - paralleltest
     - tagliatelle

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -5,19 +5,19 @@ spec:
     - --experimental_allow_proto3_optional
   vtProtobufEnabled: true
   specs:
-    - source: https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/resource.proto
+    - source: https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/resource.proto
       subdirectory: v1alpha1/
       genGateway: true
       external: false
-    - source: https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/state.proto
+    - source: https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/state.proto
       subdirectory: v1alpha1/
       genGateway: true
       external: false
-    - source: https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/runtime.proto
+    - source: https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/runtime.proto
       subdirectory: v1alpha1/
       genGateway: true
       external: false
-    - source: https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/meta.proto
+    - source: https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/meta.proto
       subdirectory: v1alpha1/
       genGateway: true
       external: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-06-27T16:57:20Z by kres ba905fc.
+# Generated on 2022-06-28T16:24:58Z by kres ba905fc-dirty.
 
 ARG TOOLCHAIN
 
@@ -21,10 +21,10 @@ RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore 
 
 # collects proto specs
 FROM scratch AS proto-specs
-ADD https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/resource.proto /api/v1alpha1/
-ADD https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/state.proto /api/v1alpha1/
-ADD https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/runtime.proto /api/v1alpha1/
-ADD https://raw.githubusercontent.com/smira/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/meta.proto /api/v1alpha1/
+ADD https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/resource.proto /api/v1alpha1/
+ADD https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/state.proto /api/v1alpha1/
+ADD https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/runtime.proto /api/v1alpha1/
+ADD https://raw.githubusercontent.com/cosi-project/specification/fd31e32e8060fec72a4f9ee7f3b7d1924ea3e4d0/proto/v1alpha1/meta.proto /api/v1alpha1/
 
 # base toolchain image
 FROM ${TOOLCHAIN} AS toolchain


### PR DESCRIPTION
Just updating the URL to the merged location, no changes to the spec.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>