### PR TITLE
fix: abort the loop in gRPC implementation of Wait

### DIFF
--- a/pkg/state/conformance/state.go
+++ b/pkg/state/conformance/state.go
@@ -6,6 +6,7 @@ package conformance
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sort"
 	"sync"
@@ -26,6 +27,27 @@ type StateSuite struct {
 	State state.State
 
 	Namespaces []resource.Namespace
+}
+
+// TearDownTest goes through extra create/destroy events to unblock watchers.
+//
+// This is required to unblock inner watch loops in 'inmem' implementation, where waiting
+// on condition variable can't be aborted by context cancellation.
+func (suite *StateSuite) TearDownTest() {
+	ctx := context.Background()
+
+	namespaces := []resource.Namespace{"default"}
+
+	if len(suite.Namespaces) > 0 {
+		namespaces = suite.Namespaces
+	}
+
+	for _, ns := range namespaces {
+		pp := NewPathResource(ns, fmt.Sprintf("cleaner%d", rand.Int63()))
+
+		suite.Require().NoError(suite.State.Create(ctx, pp))
+		suite.Require().NoError(suite.State.Destroy(ctx, pp.Metadata()))
+	}
 }
 
 func (suite *StateSuite) getNamespace() resource.Namespace {

--- a/pkg/state/impl/inmem/local_test.go
+++ b/pkg/state/impl/inmem/local_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -24,6 +25,8 @@ func TestInterfaces(t *testing.T) {
 
 func TestLocalConformance(t *testing.T) {
 	t.Parallel()
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	suite.Run(t, &conformance.StateSuite{
 		State:      state.WrapCore(inmem.NewState("default")),

--- a/pkg/state/impl/namespaced/namespaced_test.go
+++ b/pkg/state/impl/namespaced/namespaced_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -25,6 +26,8 @@ func TestInterfaces(t *testing.T) {
 
 func TestNamespacedConformance(t *testing.T) {
 	t.Parallel()
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	suite.Run(t, &conformance.StateSuite{
 		State:      state.WrapCore(namespaced.NewState(inmem.Build)),

--- a/pkg/state/protobuf/protobuf_test.go
+++ b/pkg/state/protobuf/protobuf_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -26,6 +27,8 @@ import (
 )
 
 func TestProtobufConformance(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	sock, err := os.CreateTemp("", "api*.sock")
 	require.NoError(t, err)
 


### PR DESCRIPTION
The problem was that gRPC implementation of Wait API never aborted, as
channel is never closed.

Fix that, and also add regression tests via tracing goroutine leaks in
the unit-tests.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>