### PR TITLE
feat: add encryption.Marshaler

### DIFF
--- a/pkg/state/impl/store/encryption/marshaler.go
+++ b/pkg/state/impl/store/encryption/marshaler.go
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package encryption provides encryption support for [store.Marshaler].
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state/impl/store"
+)
+
+// Marshaler encrypts and decrypts data from the underlying marshaler.
+type Marshaler struct {
+	underlying store.Marshaler
+	cipher     *Cipher
+}
+
+// NewMarshaler creates new Marshaler.
+func NewMarshaler(m store.Marshaler, c *Cipher) *Marshaler {
+	return &Marshaler{underlying: m, cipher: c}
+}
+
+// MarshalResource implements Marshaler interface.
+func (m *Marshaler) MarshalResource(r resource.Resource) ([]byte, error) {
+	encoded, err := m.underlying.MarshalResource(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource: %w", err)
+	}
+
+	encrypted, err := m.cipher.Encrypt(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt resource: %w", err)
+	}
+
+	return encrypted, nil
+}
+
+// UnmarshalResource implements Marshaler interface.
+func (m *Marshaler) UnmarshalResource(b []byte) (resource.Resource, error) { //nolint:ireturn
+	decrypted, err := m.cipher.Decrypt(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt resource: %w", err)
+	}
+
+	return m.underlying.UnmarshalResource(decrypted)
+}
+
+// Cipher provides encryption and decryption.
+type Cipher struct {
+	keyProvider KeyProvider
+	once        Once[cipherData]
+}
+
+// NewCipher creates new Cipher.
+func NewCipher(provider KeyProvider) *Cipher {
+	return &Cipher{keyProvider: provider}
+}
+
+type cipherData struct {
+	aead cipher.AEAD
+	err  error
+}
+
+func (c *Cipher) init() (cipher.AEAD, error) {
+	res := c.once.Do(func() cipherData {
+		key, err := c.keyProvider.ProvideKey()
+		if err != nil {
+			return cipherData{err: fmt.Errorf("failed to get key: %w", err)}
+		}
+
+		if len(key) != 32 {
+			return cipherData{err: fmt.Errorf("key length is not 32 bytes")}
+		}
+
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return cipherData{err: fmt.Errorf("failed to create cipher: %w", err)}
+		}
+
+		aead, err := cipher.NewGCM(block)
+		if err != nil {
+			return cipherData{err: fmt.Errorf("failed to create GCM: %w", err)}
+		}
+
+		return cipherData{aead: aead}
+	})
+	if res.err != nil {
+		return nil, res.err
+	}
+
+	// According to https://github.com/golang/go/issues/25882 cipher.AEAD is safe to share between goroutines.
+	return res.aead, nil
+}
+
+// Encrypt encrypts data.
+func (c *Cipher) Encrypt(b []byte) ([]byte, error) {
+	aead, err := c.init()
+	if err != nil {
+		return nil, fmt.Errorf("failed to init cipher: %w", err)
+	}
+
+	slc := make([]byte, 13)
+	slc[0] = 1
+
+	nonce := slc[1:]
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// We attach nonce before the encrypted data
+	encrypted := aead.Seal(slc, nonce, b, nil)
+
+	return encrypted, nil
+}
+
+// Decrypt decrypts data.
+func (c *Cipher) Decrypt(b []byte) ([]byte, error) {
+	aead, err := c.init()
+	if err != nil {
+		return nil, fmt.Errorf("failed to init cipher: %w", err)
+	}
+
+	if len(b) < 13+1 {
+		return nil, fmt.Errorf("encrypted data is too short")
+	}
+
+	if b[0] != 1 {
+		return nil, fmt.Errorf("unknown data format")
+	}
+
+	nonce := b[1:13]
+	encrypted := b[13:]
+
+	decrypted, err := aead.Open(nil, nonce, encrypted, nil)
+	if err != nil {
+		return nil, fmt.Errorf("gcm open failed: %w", err)
+	}
+
+	return decrypted, nil
+}
+
+// KeyProvider provides the encryption key.
+type KeyProvider interface {
+	ProvideKey() ([]byte, error)
+}
+
+// KeyProviderFunc is a function that provides the encryption key.
+type KeyProviderFunc func() ([]byte, error)
+
+// ProvideKey implements KeyProvider interface.
+func (f KeyProviderFunc) ProvideKey() ([]byte, error) {
+	return f()
+}
+
+// Once is small wrapper around [sync.Once]. It stores the result inside.
+type Once[T any] struct {
+	val  T
+	once sync.Once
+}
+
+// Do runs the function only once.
+func (o *Once[T]) Do(fn func() T) T {
+	o.once.Do(func() {
+		o.val = fn()
+	})
+
+	return o.val
+}

--- a/pkg/state/impl/store/encryption/marshaler_test.go
+++ b/pkg/state/impl/store/encryption/marshaler_test.go
@@ -1,0 +1,170 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package encryption_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/state/conformance"
+	"github.com/cosi-project/runtime/pkg/state/impl/store"
+	"github.com/cosi-project/runtime/pkg/state/impl/store/encryption"
+)
+
+func init() {
+	err := protobuf.RegisterResource(conformance.PathResourceType, &conformance.PathResource{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestMarshaler_Key(t *testing.T) {
+	t.Parallel()
+
+	path := conformance.NewPathResource("default", "var/run")
+
+	tests := map[string]struct {
+		expectedError string
+		keyErr        error
+		key           []byte
+	}{
+		"empty key": {
+			expectedError: "key length is not 32 bytes$",
+		},
+		"short key": {
+			key:           []byte("short"),
+			expectedError: "key length is not 32 bytes$",
+		},
+		"long key": {
+			key:           []byte("this key is too long to handle"),
+			expectedError: "key length is not 32 bytes$",
+		},
+		"normal key": {
+			key: []byte("this key is good key to use aead"),
+		},
+		"key provider error": {
+			keyErr:        fmt.Errorf("some error"),
+			expectedError: "some error$",
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cipher := encryption.NewCipher(encryption.KeyProviderFunc(func() ([]byte, error) {
+				return test.key, test.keyErr
+			}))
+			marshaler := encryption.NewMarshaler(store.ProtobufMarshaler{}, cipher)
+			_, err := marshaler.MarshalResource(path)
+
+			if test.expectedError != "" || err != nil {
+				require.Error(t, err)
+				require.Regexp(t, test.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestMarshaler_MarshalUnmarshalParallel(t *testing.T) {
+	t.Parallel()
+
+	var paths []*conformance.PathResource
+	for i := 1; i <= 1000; i++ {
+		paths = append(paths, conformance.NewPathResource("default", fmt.Sprintf("var/run/%d", i)))
+	}
+
+	cipher := encryption.NewCipher(encryption.KeyProviderFunc(func() ([]byte, error) {
+		return []byte("this key is good key to use aead"), nil
+	}))
+	marshaler := encryption.NewMarshaler(store.ProtobufMarshaler{}, cipher)
+
+	// This is also tests for race conditions if there are any.
+	for _, path := range paths {
+		path := path
+
+		t.Run(path.Metadata().ID(), func(t *testing.T) {
+			t.Parallel()
+
+			data, err := marshaler.MarshalResource(path)
+			require.NoError(t, err)
+
+			unmarshaled, err := marshaler.UnmarshalResource(data)
+			require.NoError(t, err)
+
+			require.Equal(t, resource.String(path), resource.String(unmarshaled))
+		})
+	}
+}
+
+func TestMarshaler_MarshalUnmarshalInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	path := conformance.NewPathResource("default", "var/run")
+
+	cipher := encryption.NewCipher(encryption.KeyProviderFunc(func() ([]byte, error) {
+		return []byte("this key is good key to use aead"), nil
+	}))
+	marshaler := encryption.NewMarshaler(store.ProtobufMarshaler{}, cipher)
+	data, err := marshaler.MarshalResource(path)
+	require.NoError(t, err)
+
+	cipher = encryption.NewCipher(encryption.KeyProviderFunc(func() ([]byte, error) {
+		return []byte("this key is okay key to use aead"), nil
+	}))
+	marshaler = encryption.NewMarshaler(store.ProtobufMarshaler{}, cipher)
+	_, err = marshaler.UnmarshalResource(data)
+	require.Error(t, err)
+	require.Regexp(t, "message authentication failed$", err.Error())
+}
+
+func TestMarshaler_CorruptedData(t *testing.T) {
+	t.Parallel()
+
+	path := conformance.NewPathResource("default", "var/run")
+
+	cipher := encryption.NewCipher(encryption.KeyProviderFunc(func() ([]byte, error) {
+		return []byte("this key is good key to use aead"), nil
+	}))
+	marshaler := encryption.NewMarshaler(store.ProtobufMarshaler{}, cipher)
+	data, err := marshaler.MarshalResource(path)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		expectedError string
+		data          []byte
+	}{
+		"short data": {
+			data:          data[:13],
+			expectedError: "encrypted data is too short$",
+		},
+		"corrupted data": {
+			data:          append(append(data[:13], 0x00), data[14:]...),
+			expectedError: "message authentication failed$",
+		},
+		"wrong header": {
+			data:          append([]byte{0x00}, data[1:]...),
+			expectedError: "unknown data format$",
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := marshaler.UnmarshalResource(test.data)
+			require.Error(t, err)
+			require.Regexp(t, test.expectedError, err.Error())
+		})
+	}
+}


### PR DESCRIPTION
This `Marshaler` is used to encrypt data that was marshaled by the underlying `store.Marshaler`.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>