### PR TITLE
chore: cmd/runtime move from channels to signal.NotifyContext

### DIFF
--- a/cmd/runtime/main.go
+++ b/cmd/runtime/main.go
@@ -48,17 +48,8 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() {
-		defer cancel()
-
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGTERM, os.Interrupt)
-
-		select {
-		case <-sigCh:
-		case <-ctx.Done():
-		}
-	}()
+	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGTERM, os.Interrupt)
+	defer cancel()
 
 	var (
 		network = "unix"


### PR DESCRIPTION
Refactor code a bit since we already require Go 1.19 and `signal.NotifyContext` requires Go 1.16

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>