### PR TITLE
chore: update conformance test and example with encryption.Marshaler

### DIFF
--- a/pkg/state/impl/store/bolt/example_test.go
+++ b/pkg/state/impl/store/bolt/example_test.go
@@ -5,26 +5,59 @@
 package bolt_test
 
 import (
+	"context"
+	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 
 	"go.etcd.io/bbolt"
 
+	"github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/runtime/pkg/state/impl/store"
 	"github.com/cosi-project/runtime/pkg/state/impl/store/bolt"
+	"github.com/cosi-project/runtime/pkg/state/impl/store/encryption"
 )
 
+type ExampleSpec = protobuf.ResourceSpec[v1alpha1.Metadata, *v1alpha1.Metadata]
+
+type ExampleRD struct{}
+
+func (ExampleRD) ResourceDefinition(_ resource.Metadata, _ ExampleSpec) meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type: "testResource",
+	}
+}
+
 func Example() {
-	// use protobuf marshaler, resources should implement protobuf marshaling
-	marshaler := store.ProtobufMarshaler{}
+	// use encryption marshaler on top of protobuf marshaler, resources should implement protobuf marshaling
+	marshaler := encryption.NewMarshaler(
+		store.ProtobufMarshaler{},
+		encryption.NewCipher(
+			encryption.KeyProviderFunc(func() ([]byte, error) {
+				return []byte("this key len is exactly 32 bytes"), nil
+			}),
+		),
+	)
+
+	tempDir, err := os.MkdirTemp("", "bolt-example")
+	if err != nil {
+		fmt.Println(err)
+
+		return
+	}
 
 	// open the backing store, it will be shared across namespaces
-	store, err := bolt.NewBackingStore(
+	backingStore, err := bolt.NewBackingStore(
 		func() (*bbolt.DB, error) {
-			return bbolt.Open("cosi.db", 0o600, nil)
+			return bbolt.Open(filepath.Join(tempDir, "cosi.db"), 0o600, nil)
 		},
 		marshaler,
 	)
@@ -32,7 +65,13 @@ func Example() {
 		log.Fatalf("error opening bolt db: %v", err)
 	}
 
-	defer store.Close() //nolint:errcheck
+	defer func() {
+		if storeErr := backingStore.Close(); storeErr != nil {
+			fmt.Println(storeErr)
+
+			return
+		}
+	}()
 
 	// create resource state with following namespaces
 	// * backed by BoltDB: persistent, system
@@ -43,7 +82,7 @@ func Example() {
 			case "persistent", "system":
 				// use in-memory state backed by BoltDB
 				return inmem.NewStateWithOptions(
-					inmem.WithBackingStore(store.WithNamespace(ns)),
+					inmem.WithBackingStore(backingStore.WithNamespace(ns)),
 				)(ns)
 			case "runtime":
 				return inmem.NewState(ns)
@@ -53,5 +92,54 @@ func Example() {
 		},
 	))
 
-	_ = resources
+	r1 := typed.NewResource[ExampleSpec, ExampleRD](
+		resource.NewMetadata(
+			"persistent",
+			"testResource",
+			"example-resource-id",
+			resource.VersionUndefined,
+		),
+		protobuf.NewResourceSpec(&v1alpha1.Metadata{Version: "v0.1.0"}),
+	)
+
+	if err = resources.Create(context.Background(), r1); err != nil {
+		fmt.Println("error getting resource:", err)
+
+		return
+	}
+
+	result, err := resources.Get(
+		context.Background(),
+		resource.NewMetadata(
+			"persistent",
+			"testResource",
+			"example-resource-id",
+			resource.VersionUndefined,
+		),
+	)
+	if err != nil {
+		fmt.Println("error getting resource:", err)
+
+		return
+	}
+
+	fmt.Println(result.Metadata().ID())
+
+	result, err = resources.Get(
+		context.Background(),
+		resource.NewMetadata(
+			"persistent",
+			"testResource",
+			"non-existent-resource",
+			resource.VersionUndefined,
+		),
+	)
+	if err != nil {
+		fmt.Println("error getting resource:", err)
+
+		return
+	}
+	// Output:
+	// example-resource-id
+	// error getting resource: resource testResource(persistent/non-existent-resource@undefined) doesn't exist
 }


### PR DESCRIPTION
Use encryption.Marshaler in example and conformance test. Also update example to run on each go test invocation.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>