### PR TITLE
feat: implement generic (template) transform controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3
 	github.com/hashicorp/go-memdb v1.3.3
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/siderolabs/gen v0.3.0
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/siderolabs/protoenc v0.2.0
@@ -32,6 +33,7 @@ require (
 	github.com/ProtonMail/go-mime v0.0.0-20220302105931-303f85f7fe0f // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,14 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 h1:lLT7ZLSzGLI08vc9cpd+tYmNWjdKDqyr/2L+f6U12Fk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-immutable-radix v1.3.0 h1:8exGP7ego3OmkfksihtSouGMZ+hQrhxx+FVELeXpVPE=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v1.3.3 h1:oGfEWrFuxtIUF3W2q/Jzt6G85TrMk9ey6XfYLvVe1Wo=
 github.com/hashicorp/go-memdb v1.3.3/go.mod h1:uBTr1oQbtuMgd1SSGoR8YV27eT3sBHbYiNm53bMpgSg=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/pkg/controller/generic/generic.go
+++ b/pkg/controller/generic/generic.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package generic provides implementations of generic controllers.
+package generic
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+)
+
+// ResourceWithRD is a resource providing resource definition.
+//
+// ResourceWithRD allows to pull resource namespace and type from the RD.
+type ResourceWithRD interface {
+	resource.Resource
+	meta.ResourceDefinitionProvider
+}
+
+// NamedController is provides Name() method.
+type NamedController struct {
+	ControllerName string
+}
+
+// Name implements controller.Controller interface.
+func (c *NamedController) Name() string {
+	return c.ControllerName
+}

--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -1,0 +1,369 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package transform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// Controller provides a generic implementation of a controller which implements controller transforming Input resources into Output resources.
+//
+// Controller supports full flow with finalizers:
+//   - if other controllers set finalizers on this controller outputs, this controller will handle this and wait for the finalizers
+//     to be fully removed before attempting to delete the output.
+//   - if this controller is configured to set finalizers on its inputs, the finalizer will only be removed when matching output is destroyed.
+type Controller[Input generic.ResourceWithRD, Output generic.ResourceWithRD] struct {
+	mapFunc              func(Input) Output
+	transformFunc        func(context.Context, controller.Reader, *zap.Logger, Input, Output) error
+	finalizerRemovalFunc func(context.Context, controller.Reader, *zap.Logger, Input) error
+	generic.NamedController
+	options ControllerOptions
+}
+
+// Settings configures the controller.
+type Settings[Input generic.ResourceWithRD, Output generic.ResourceWithRD] struct { //nolint:govet
+	// Name is the name of the controller.
+	Name string
+	// MapMetadataFunc defines a function which creates new empty Output based on Input.
+	//
+	// Only Output metadata is important, the spec is ignored.
+	MapMetadataFunc func(Input) Output
+	// TransformFunc should modify Output based on Input and any additional resources fetched via Reader.
+	//
+	// If TransformFunc returns error tagged with SkipReconcileTag, the error is ignored and the controller will
+	// call reconcile on next event.
+	// If TransformFunc returns any other error, controller will fail.
+	TransformFunc func(context.Context, controller.Reader, *zap.Logger, Input, Output) error
+	// FinalizerRemovalFunc is called when Input is being torn down while Input Finalizers are enabled.
+	//
+	// This function defines the pre-checks to be done before finalizer on the input can be removed.
+	// If this function returns an error, the finalizer won't be removed and this controller will fail.
+	// If FinalizerRemoveFunc returns an error tagged with SkipReconcileTag, the error is ignored and the controller will
+	// retry on next reconcile event.
+	FinalizerRemovalFunc func(context.Context, controller.Reader, *zap.Logger, Input) error
+}
+
+// NewController creates a new TransformController.
+func NewController[Input generic.ResourceWithRD, Output generic.ResourceWithRD](
+	settings Settings[Input, Output],
+	opts ...ControllerOption,
+) *Controller[Input, Output] {
+	var options ControllerOptions
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	switch {
+	case settings.MapMetadataFunc == nil:
+		panic("MapFunc is required")
+	case settings.TransformFunc == nil:
+		panic("TransformFunc is required")
+	case options.inputFinalizers && settings.FinalizerRemovalFunc == nil:
+		panic("FinalizerRemovalFunc is required when input finalizers are enabled")
+	}
+
+	return &Controller[Input, Output]{
+		NamedController: generic.NamedController{
+			ControllerName: settings.Name,
+		},
+		mapFunc:              settings.MapMetadataFunc,
+		transformFunc:        settings.TransformFunc,
+		finalizerRemovalFunc: settings.FinalizerRemovalFunc,
+		options:              options,
+	}
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *Controller[Input, Output]) Inputs() []controller.Input {
+	var (
+		input  Input
+		output Output
+	)
+
+	inputKind := controller.InputWeak
+
+	if ctrl.options.inputFinalizers {
+		inputKind = controller.InputStrong
+	}
+
+	inputs := []controller.Input{
+		{
+			Namespace: input.ResourceDefinition().DefaultNamespace,
+			Type:      input.ResourceDefinition().Type,
+			Kind:      inputKind,
+		},
+		{
+			Namespace: output.ResourceDefinition().DefaultNamespace,
+			Type:      output.ResourceDefinition().Type,
+			Kind:      controller.InputDestroyReady,
+		},
+	}
+
+	return append(inputs, ctrl.options.extraInputs...)
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *Controller[Input, Output]) Outputs() []controller.Output {
+	var output Output
+
+	return []controller.Output{
+		{
+			Type: output.ResourceDefinition().Type,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+type runState struct {
+	multiErr *multierror.Error
+
+	// touchedOutputIDs is the list of outputs which should be kept.
+	touchedOutputIDs map[resource.ID]struct{}
+	// removeInputFinalizers is a list of inputs which can have finalizers removed.
+	// maps out ID -> input MD
+	removeInputFinalizers map[resource.ID]*resource.Metadata
+}
+
+// Run implements controller.Controller interface.
+func (ctrl *Controller[Input, Output]) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	var (
+		zeroInput  Input
+		zeroOutput Output
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		// controller runs in two phases:
+		//  - list all inputs, and transform inputs into outputs
+		//  - perform cleanup on outputs
+		//
+		// in any case, controller will process all resources, and report a final error as a combination of all errors
+		//
+		// between the phases, some state is being kept:
+		//  - outputs which should be kept (they have live inputs): `touchedOutputIDs`
+		//  - inputs finalizers which can now be removed: `removeInputFinalizers`
+
+		state := runState{
+			touchedOutputIDs:      map[resource.ID]struct{}{},
+			removeInputFinalizers: map[resource.ID]*resource.Metadata{},
+		}
+
+		if err := ctrl.processInputs(
+			ctx, r, logger,
+			&state,
+			resource.NewMetadata(zeroInput.ResourceDefinition().DefaultNamespace, zeroInput.ResourceDefinition().Type, "", resource.VersionUndefined),
+		); err != nil {
+			return err
+		}
+
+		if err := ctrl.cleanupOutputs(
+			ctx, r, logger,
+			&state,
+			resource.NewMetadata(zeroOutput.ResourceDefinition().DefaultNamespace, zeroOutput.ResourceDefinition().Type, "", resource.VersionUndefined),
+		); err != nil {
+			return err
+		}
+
+		if err := state.multiErr.ErrorOrNil(); err != nil {
+			return err
+		}
+	}
+}
+
+func (ctrl *Controller[Input, Output]) processInputs(
+	ctx context.Context,
+	r controller.Runtime,
+	logger *zap.Logger,
+	runState *runState,
+	inputMetadata resource.Metadata,
+) error {
+	inputItems, err := safe.ReaderList[Input](ctx, r, inputMetadata)
+	if err != nil {
+		return fmt.Errorf("error listing input resources: %w", err)
+	}
+
+	// create outputs based on inputs
+	for iter := safe.IteratorFromList(inputItems); iter.Next(); {
+		in := iter.Value()
+
+		mappedOut := ctrl.mapFunc(in)
+
+		if in.Metadata().Phase() == resource.PhaseTearingDown {
+			ctrl.reconcileTearingDownInput(ctx, r, logger, runState, in, mappedOut)
+
+			// skip normal reconciliation
+			continue
+		}
+
+		// in this part of the function input resource is in PhaseRunning
+		runState.touchedOutputIDs[mappedOut.Metadata().ID()] = struct{}{}
+
+		// if the input finalizers are enabled, set the finalizer on input asap
+		if ctrl.options.inputFinalizers {
+			if in.Metadata().Finalizers().Add(ctrl.Name()) {
+				if err = r.AddFinalizer(ctx, in.Metadata(), ctrl.Name()); err != nil {
+					runState.multiErr = multierror.Append(runState.multiErr, err)
+
+					continue
+				} else {
+					logger.Debug("added finalizer to input resource",
+						zap.Stringer("input", in.Metadata()),
+						zap.String("finalizer", ctrl.Name()),
+					)
+				}
+			}
+		}
+
+		if err = safe.WriterModify(ctx, r, mappedOut, func(out Output) error {
+			return ctrl.transformFunc(ctx, r, logger, in, out)
+		}); err != nil {
+			if state.IsConflictError(err) {
+				// conflict due to wrong phase, skip it
+				continue
+			}
+
+			if xerrors.TagIs[SkipReconcileTag](err) {
+				// skip this resource
+				continue
+			}
+
+			runState.multiErr = multierror.Append(runState.multiErr,
+				fmt.Errorf("error running transform on %s(%q): %w", in.Metadata().Type(), in.Metadata().ID(), err),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (ctrl *Controller[Input, Output]) reconcileTearingDownInput(
+	ctx context.Context,
+	r controller.Runtime,
+	logger *zap.Logger,
+	runState *runState,
+	in Input,
+	mappedOut Output,
+) {
+	// if input finalizers are not enabled, nothing to do
+	if !ctrl.options.inputFinalizers {
+		return
+	}
+
+	// if the finalizer is not set, do nothing
+	if in.Metadata().Finalizers().Add(ctrl.Name()) {
+		return
+	}
+
+	// the input resource is being torn down and if the finalizer is set on the resource:
+	// run the finalizer removal function until it succeeds
+	if err := ctrl.finalizerRemovalFunc(ctx, r, logger, in); err != nil {
+		if !xerrors.TagIs[SkipReconcileTag](err) {
+			runState.multiErr = multierror.Append(runState.multiErr, fmt.Errorf("error reconciling finalizer removal: %w", err))
+		}
+
+		// don't remove the output resource yet
+		runState.touchedOutputIDs[mappedOut.Metadata().ID()] = struct{}{}
+
+		return
+	}
+
+	// finalizer is ready to be removed on the input as soon as the output is removed
+	runState.removeInputFinalizers[mappedOut.Metadata().ID()] = in.Metadata()
+}
+
+func (ctrl *Controller[Input, Output]) cleanupOutputs(
+	ctx context.Context,
+	r controller.Runtime,
+	logger *zap.Logger,
+	runState *runState,
+	outputMetadata resource.Metadata,
+) error {
+	// clean up outputs
+	outputItems, err := safe.ReaderList[Output](ctx, r, outputMetadata)
+	if err != nil {
+		return fmt.Errorf("error listing output resources: %w", err)
+	}
+
+	for iter := safe.IteratorFromList(outputItems); iter.Next(); {
+		out := iter.Value()
+
+		// output not owned by this controller, skip it
+		if out.Metadata().Owner() != ctrl.Name() {
+			delete(runState.removeInputFinalizers, out.Metadata().ID())
+
+			continue
+		}
+
+		// this output was touched (has active input), skip it
+		if _, touched := runState.touchedOutputIDs[out.Metadata().ID()]; touched {
+			delete(runState.removeInputFinalizers, out.Metadata().ID())
+
+			continue
+		}
+
+		// attempt teardown
+		var ready bool
+
+		ready, err = r.Teardown(ctx, out.Metadata())
+		if err != nil {
+			delete(runState.removeInputFinalizers, out.Metadata().ID())
+
+			runState.multiErr = multierror.Append(runState.multiErr, err)
+
+			continue
+		}
+
+		logger.Debug("triggered teardown of output resource",
+			zap.Stringer("output", out.Metadata()),
+			zap.Bool("ready", ready),
+		)
+
+		if !ready {
+			// still some finalizers left on the output, controller will be re-triggered
+			delete(runState.removeInputFinalizers, out.Metadata().ID())
+
+			continue
+		}
+
+		if err = r.Destroy(ctx, out.Metadata()); err != nil {
+			delete(runState.removeInputFinalizers, out.Metadata().ID())
+
+			runState.multiErr = multierror.Append(runState.multiErr, err)
+		}
+	}
+
+	// clean up tearingDownInputs finalizers, as matching outputs are gone now
+	//
+	// if some output failed to be removed in the loop above, it is removed from the map
+	for _, inMd := range runState.removeInputFinalizers {
+		if err = r.RemoveFinalizer(ctx, inMd, ctrl.Name()); err != nil {
+			runState.multiErr = multierror.Append(runState.multiErr, err)
+		} else {
+			logger.Debug("removed finalizer to input resource",
+				zap.Stringer("input", inMd),
+				zap.String("finalizer", ctrl.Name()),
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/generic/transform/options.go
+++ b/pkg/controller/generic/transform/options.go
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package transform
+
+import "github.com/cosi-project/runtime/pkg/controller"
+
+// ControllerOptions configures TransformController.
+type ControllerOptions struct {
+	extraInputs     []controller.Input
+	inputFinalizers bool
+}
+
+// ControllerOption is an option for TransformController.
+type ControllerOption func(*ControllerOptions)
+
+// WithExtraInputs adds extra inputs to the controller.
+func WithExtraInputs(inputs ...controller.Input) ControllerOption {
+	return func(o *ControllerOptions) {
+		o.extraInputs = append(o.extraInputs, inputs...)
+	}
+}
+
+// WithInputFinalizers enables setting finalizers on controller inputs.
+//
+// The finalizer on input will be removed only when matching output is destroyed.
+func WithInputFinalizers() ControllerOption {
+	return func(o *ControllerOptions) {
+		o.inputFinalizers = true
+	}
+}

--- a/pkg/controller/generic/transform/resource_test.go
+++ b/pkg/controller/generic/transform/resource_test.go
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package transform_test
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+)
+
+// ANamespaceName is the namespace of A resource.
+const ANamespaceName = resource.Namespace("ns-a")
+
+// AType is the type of A.
+const AType = resource.Type("A.test.cosi.dev")
+
+// A is a test resource.
+type A = typed.Resource[ASpec, ARD]
+
+// NewA initializes a A resource.
+func NewA(id resource.ID, spec ASpec) *A {
+	return typed.NewResource[ASpec, ARD](
+		resource.NewMetadata(ANamespaceName, AType, id, resource.VersionUndefined),
+		spec,
+	)
+}
+
+// ARD provides auxiliary methods for A.
+type ARD struct{}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (ARD) ResourceDefinition(_ resource.Metadata, _ ASpec) meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             AType,
+		DefaultNamespace: ANamespaceName,
+	}
+}
+
+// ASpec provides A definition.
+type ASpec struct {
+	Str string
+	Int int
+}
+
+// DeepCopy generates a deep copy of NamespaceSpec.
+func (a ASpec) DeepCopy() ASpec {
+	return a
+}
+
+// BNamespaceName is the namespace of B resource.
+const BNamespaceName = resource.Namespace("ns-b")
+
+// BType is the type of B.
+const BType = resource.Type("B.test.cosi.dev")
+
+// B is a test resource.
+type B = typed.Resource[BSpec, BRD]
+
+// NewB initializes a B resource.
+func NewB(id resource.ID, spec BSpec) *B {
+	return typed.NewResource[BSpec, BRD](
+		resource.NewMetadata(BNamespaceName, BType, id, resource.VersionUndefined),
+		spec,
+	)
+}
+
+// BRD provides auxiliary methods for B.
+type BRD struct{}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (BRD) ResourceDefinition(_ resource.Metadata, _ BSpec) meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             BType,
+		DefaultNamespace: BNamespaceName,
+	}
+}
+
+// BSpec provides B definition.
+type BSpec struct {
+	Out string
+}
+
+// DeepCopy generates a deep copy of BSpec.
+func (b BSpec) DeepCopy() BSpec {
+	return b
+}
+
+var (
+	_ resource.Resource               = &A{}
+	_ resource.Resource               = &B{}
+	_ meta.ResourceDefinitionProvider = &A{}
+	_ meta.ResourceDefinitionProvider = &B{}
+)

--- a/pkg/controller/generic/transform/transform.go
+++ b/pkg/controller/generic/transform/transform.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package transform provides a generic implementation of controller which transforms resources A into resources B.
+package transform
+
+// SkipReconcileTag is used to tag errors when reconciliation should be skipped without an error.
+//
+// It's useful when next reconcile event should bring things into order.
+type SkipReconcileTag struct{}

--- a/pkg/controller/generic/transform/transform_test.go
+++ b/pkg/controller/generic/transform/transform_test.go
@@ -1,0 +1,372 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:goconst
+package transform_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/transform"
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/logging"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+)
+
+type ABController = transform.Controller[*A, *B]
+
+func NewABController(reconcileTeardownCh <-chan struct{}, opts ...transform.ControllerOption) *ABController {
+	return transform.NewController(
+		transform.Settings[*A, *B]{
+			Name: "TransformABController",
+			MapMetadataFunc: func(in *A) *B {
+				return NewB("transformed-"+in.Metadata().ID(), BSpec{})
+			},
+			TransformFunc: func(ctx context.Context, r controller.Reader, l *zap.Logger, in *A, out *B) error {
+				if in.TypedSpec().Int < 0 {
+					return fmt.Errorf("hate negative numbers")
+				}
+
+				out.TypedSpec().Out = fmt.Sprintf("%q-%d", in.TypedSpec().Str, in.TypedSpec().Int)
+
+				return nil
+			},
+			FinalizerRemovalFunc: func(ctx context.Context, r controller.Reader, l *zap.Logger, in *A) error {
+				if in.TypedSpec().Str != "reconcile-teardown" {
+					return fmt.Errorf("not allowed to reconcile teardown")
+				}
+
+				select {
+				case <-reconcileTeardownCh:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		},
+		opts...,
+	)
+}
+
+func TestSimpleMap(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		require.NoError(t, runtime.RegisterController(NewABController(nil)))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{Str: "foo", Int: 1}),
+			NewA("2", ASpec{Str: "bar", Int: 2}),
+			NewA("3", ASpec{Str: "baz", Int: 3}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {
+			switch r.Metadata().ID() {
+			case "transformed-1":
+				assert.Equal(`"foo"-1`, r.TypedSpec().Out)
+			case "transformed-2":
+				assert.Equal(`"bar"-2`, r.TypedSpec().Out)
+			case "transformed-3":
+				assert.Equal(`"baz"-3`, r.TypedSpec().Out)
+			}
+		})
+
+		require.NoError(t, st.Create(ctx, NewA("4", ASpec{Str: "foobar", Int: 4})))
+		_, err := safe.StateUpdateWithConflicts(ctx, st, NewA("1", ASpec{}).Metadata(), func(a *A) error {
+			a.TypedSpec().Str = "foo2"
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3", "transformed-4"}, func(r *B, assert *assert.Assertions) {
+			switch r.Metadata().ID() {
+			case "transformed-1":
+				assert.Equal(`"foo2"-1`, r.TypedSpec().Out)
+			case "transformed-2":
+				assert.Equal(`"bar"-2`, r.TypedSpec().Out)
+			case "transformed-3":
+				assert.Equal(`"baz"-3`, r.TypedSpec().Out)
+			case "transformed-4":
+				assert.Equal(`"foobar"-4`, r.TypedSpec().Out)
+			}
+		})
+	})
+}
+
+func TestMapWithErrors(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		require.NoError(t, runtime.RegisterController(NewABController(nil)))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{Str: "foo", Int: 1}),
+			NewA("2", ASpec{Str: "bar", Int: -2}),
+			NewA("3", ASpec{Str: "baz", Int: 3}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-3"}, func(r *B, assert *assert.Assertions) {
+			switch r.Metadata().ID() {
+			case "transformed-1":
+				assert.Equal(`"foo"-1`, r.TypedSpec().Out)
+			case "transformed-3":
+				assert.Equal(`"baz"-3`, r.TypedSpec().Out)
+			}
+		})
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-2")
+
+		_, err := safe.StateUpdateWithConflicts(ctx, st, NewA("2", ASpec{}).Metadata(), func(a *A) error {
+			a.TypedSpec().Int = 2
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {
+			switch r.Metadata().ID() {
+			case "transformed-1":
+				assert.Equal(`"foo"-1`, r.TypedSpec().Out)
+			case "transformed-2":
+				assert.Equal(`"bar"-2`, r.TypedSpec().Out)
+			case "transformed-3":
+				assert.Equal(`"baz"-3`, r.TypedSpec().Out)
+			}
+		})
+	})
+}
+
+func TestDestroy(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		require.NoError(t, runtime.RegisterController(NewABController(nil)))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{}),
+			NewA("2", ASpec{}),
+			NewA("3", ASpec{}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+
+		require.NoError(t, st.Destroy(ctx, NewA("1", ASpec{}).Metadata()))
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-1")
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+
+		_, err := st.Teardown(ctx, NewA("3", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+
+		require.NoError(t, st.Destroy(ctx, NewA("3", ASpec{}).Metadata()))
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-3")
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2"}, func(r *B, assert *assert.Assertions) {})
+	})
+}
+
+func TestDestroyOutputFinalizers(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		require.NoError(t, runtime.RegisterController(NewABController(nil)))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{}),
+			NewA("2", ASpec{}),
+			NewA("3", ASpec{}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+
+		// add finalizers
+		const finalizer = "foo.cosi"
+
+		for _, id := range []resource.ID{"transformed-1", "transformed-2", "transformed-3"} {
+			require.NoError(t, st.AddFinalizer(ctx, NewB(id, BSpec{}).Metadata(), finalizer))
+		}
+
+		_, err := st.Teardown(ctx, NewA("3", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {
+			if r.Metadata().ID() == "transformed-3" {
+				assert.Equal(resource.PhaseTearingDown, r.Metadata().Phase())
+			}
+		})
+
+		require.NoError(t, st.Destroy(ctx, NewA("3", ASpec{}).Metadata()))
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {
+			if r.Metadata().ID() == "transformed-3" {
+				assert.Equal(resource.PhaseTearingDown, r.Metadata().Phase())
+			}
+		})
+
+		require.NoError(t, st.RemoveFinalizer(ctx, NewB("transformed-3", BSpec{}).Metadata(), finalizer))
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-3")
+	})
+}
+
+func TestDestroyInputFinalizers(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		teardownCh := make(chan struct{})
+
+		require.NoError(t, runtime.RegisterController(NewABController(teardownCh, transform.WithInputFinalizers())))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{Str: "reconcile-teardown"}),
+			NewA("2", ASpec{Str: "reconcile-teardown"}),
+			NewA("3", ASpec{Str: "reconcile-teardown"}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+
+		// controller should set finalizers on inputs
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"1", "2", "3"}, func(r *A, assert *assert.Assertions) {
+			assert.False(r.Metadata().Finalizers().Add("TransformABController"))
+		})
+
+		// teardown an input, controller should clean up and remove finalizers
+		_, err := st.Teardown(ctx, NewA("3", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		teardownCh <- struct{}{}
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-3")
+
+		require.NoError(t, st.Destroy(ctx, NewA("3", ASpec{}).Metadata()))
+
+		// now same flow, but this time add our own finalizer on the output
+		const finalizer = "foo.cosi"
+
+		require.NoError(t, st.AddFinalizer(ctx, NewB("transformed-2", BSpec{}).Metadata(), finalizer))
+
+		_, err = st.Teardown(ctx, NewA("2", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		teardownCh <- struct{}{}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2"}, func(r *B, assert *assert.Assertions) {
+			if r.Metadata().ID() == "transformed-2" {
+				assert.Equal(resource.PhaseTearingDown, r.Metadata().Phase())
+			}
+		})
+
+		require.NoError(t, st.RemoveFinalizer(ctx, NewB("transformed-2", BSpec{}).Metadata(), finalizer))
+
+		teardownCh <- struct{}{}
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-2")
+
+		require.NoError(t, st.Destroy(ctx, NewA("2", ASpec{}).Metadata()))
+	})
+}
+
+func TestDestroyReconcileTeardown(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		teardownCh := make(chan struct{})
+
+		require.NoError(t, runtime.RegisterController(
+			NewABController(
+				teardownCh,
+				transform.WithInputFinalizers(),
+			)))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{Str: "reconcile-teardown"}),
+			NewA("2", ASpec{Str: "reconcile-teardown"}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2"}, func(r *B, assert *assert.Assertions) {})
+
+		// controller should set finalizers on inputs
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"1", "2"}, func(r *A, assert *assert.Assertions) {
+			assert.False(r.Metadata().Finalizers().Add("TransformABController"))
+		})
+
+		// set finalizers on outputs
+		const finalizer = "foo.cosi"
+
+		require.NoError(t, st.AddFinalizer(ctx, NewB("transformed-2", BSpec{}).Metadata(), finalizer))
+
+		// teardown an input, controller should start reconciling this input to remove its own finalizer
+		_, err := st.Teardown(ctx, NewA("2", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2"}, func(r *B, assert *assert.Assertions) {
+			assert.Equal(resource.PhaseRunning, r.Metadata().Phase())
+		})
+
+		teardownCh <- struct{}{}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2"}, func(r *B, assert *assert.Assertions) {
+			assert.Equal(resource.PhaseTearingDown, r.Metadata().Phase())
+		})
+
+		// controller should now remove its own finalizer
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"2"}, func(r *A, assert *assert.Assertions) {
+			assert.True(r.Metadata().Finalizers().Add("TestABController"))
+		})
+
+		require.NoError(t, st.RemoveFinalizer(ctx, NewB("transformed-2", BSpec{}).Metadata(), finalizer))
+
+		teardownCh <- struct{}{}
+
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-2")
+	})
+}
+
+func setup(t *testing.T, f func(ctx context.Context, st state.State, rt *runtime.Runtime)) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	logger := logging.DefaultLogger()
+
+	runtime, err := runtime.NewRuntime(st, logger)
+	require.NoError(err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		assert.NoError(runtime.Run(ctx))
+	}()
+
+	t.Cleanup(wg.Wait)
+
+	f(ctx, st, runtime)
+}

--- a/pkg/resource/rtestutils/assertions.go
+++ b/pkg/resource/rtestutils/assertions.go
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rtestutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// AssertResources asserts on a resource list.
+func AssertResources[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, ids []resource.ID, assertionFunc func(r R, assertion *assert.Assertions)) {
+	require := require.New(t)
+
+	var r R
+
+	rds := r.ResourceDefinition()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	watchCh := make(chan state.Event)
+
+	require.NoError(st.WatchKind(ctx, resource.NewMetadata(rds.DefaultNamespace, rds.Type, "", resource.VersionUndefined), watchCh))
+
+	for {
+		ok := 0
+
+		var aggregator assertionAggregator
+		asserter := assert.New(&aggregator)
+
+		for _, id := range ids {
+			res, err := safe.StateGet[R](ctx, st, resource.NewMetadata(rds.DefaultNamespace, rds.Type, id, resource.VersionUndefined))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					asserter.NoError(err)
+
+					continue
+				}
+
+				require.NoError(err)
+			}
+
+			aggregator.hadErrors = false
+
+			assertionFunc(res, asserter)
+
+			if !aggregator.hadErrors {
+				ok++
+			}
+		}
+
+		if ok == len(ids) {
+			return
+		}
+
+		t.Logf("ok: %d/%d, assertions:\n%s", ok, len(ids), &aggregator)
+
+		select {
+		case <-ctx.Done():
+			require.FailNow("timeout", "assertions:\n%s", &aggregator)
+		case <-watchCh:
+		}
+	}
+}
+
+// AssertNoResource asserts that a resource no longer exists.
+func AssertNoResource[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, id resource.ID) {
+	require := require.New(t)
+
+	var r R
+
+	rds := r.ResourceDefinition()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	watchCh := make(chan state.Event)
+
+	require.NoError(st.Watch(ctx, resource.NewMetadata(rds.DefaultNamespace, rds.Type, id, resource.VersionUndefined), watchCh))
+
+	for {
+		select {
+		case <-ctx.Done():
+			require.FailNow("timeout", "resource still exists: %q", id)
+		case ev := <-watchCh:
+			if ev.Type == state.Destroyed {
+				return
+			}
+		}
+	}
+}
+
+// AssertAll asserts on all resources of a kind.
+func AssertAll[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, assertionFunc func(r R, assertion *assert.Assertions)) {
+	AssertResources(ctx, t, st, ResourceIDs[R](ctx, t, st), assertionFunc)
+}

--- a/pkg/resource/rtestutils/destroy.go
+++ b/pkg/resource/rtestutils/destroy.go
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rtestutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/siderolabs/go-pointer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// DestroyAll performs graceful teardown/destroy sequence for all resources of type.
+func DestroyAll[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State) {
+	Destroy[R](ctx, t, st, ResourceIDsWithOwner[R](ctx, t, st, pointer.To("")))
+}
+
+// Destroy performs graceful teardown/destroy sequence for specified IDs.
+func Destroy[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, ids []string) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	require := require.New(t)
+
+	var r R
+
+	rds := r.ResourceDefinition()
+
+	for _, id := range ids {
+		_, err := st.Teardown(ctx, resource.NewMetadata(rds.DefaultNamespace, rds.Type, id, resource.VersionUndefined))
+		require.NoError(err)
+	}
+
+	watchCh := make(chan safe.WrappedStateEvent[R])
+
+	require.NoError(safe.StateWatchKind(ctx, st, resource.NewMetadata(rds.DefaultNamespace, rds.Type, "", resource.VersionUndefined), watchCh, state.WithBootstrapContents(true)))
+
+	left := len(ids)
+
+	for left > 0 {
+		var event safe.WrappedStateEvent[R]
+
+		select {
+		case <-ctx.Done():
+			require.FailNow("timeout", "left: %d %s", left, rds.Type)
+		case event = <-watchCh:
+		}
+
+		switch event.Type() {
+		case state.Destroyed:
+			left--
+		case state.Updated, state.Created:
+			r, err := event.Resource()
+			require.NoError(err)
+
+			if r.Metadata().Phase() == resource.PhaseTearingDown && r.Metadata().Finalizers().Empty() {
+				// time to destroy
+				require.NoError(st.Destroy(ctx, r.Metadata()))
+
+				t.Logf("cleaned up %s ID %q", rds.Type, r.Metadata().ID())
+			}
+		}
+	}
+}

--- a/pkg/resource/rtestutils/errors.go
+++ b/pkg/resource/rtestutils/errors.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rtestutils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type assertionAggregator struct {
+	errors    map[string]struct{}
+	hadErrors bool
+}
+
+func (agg *assertionAggregator) Errorf(format string, args ...any) {
+	errorString := fmt.Sprintf(format, args...)
+
+	if agg.errors == nil {
+		agg.errors = make(map[string]struct{})
+	}
+
+	agg.errors[errorString] = struct{}{}
+	agg.hadErrors = true
+}
+
+func (agg *assertionAggregator) String() string {
+	lines := make([]string, 0, len(agg.errors))
+
+	for errorString := range agg.errors {
+		lines = append(lines, " * "+errorString)
+	}
+
+	sort.Strings(lines)
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/resource/rtestutils/ids.go
+++ b/pkg/resource/rtestutils/ids.go
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package rtestutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// ResourceIDsWithOwner returns a list of resource IDs and filters them by owner (if set).
+func ResourceIDsWithOwner[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, owner *string, options ...state.ListOption) []resource.ID {
+	require := require.New(t)
+
+	var r R
+
+	rds := r.ResourceDefinition()
+
+	items, err := st.List(ctx, resource.NewMetadata(rds.DefaultNamespace, rds.Type, "", resource.VersionUndefined), options...)
+	require.NoError(err)
+
+	ids := make([]resource.ID, 0, len(items.Items))
+
+	for _, item := range items.Items {
+		if owner != nil && item.Metadata().Owner() != *owner {
+			continue
+		}
+
+		ids = append(ids, item.Metadata().ID())
+	}
+
+	return ids
+}
+
+// ResourceIDs returns a list of resource IDs.
+func ResourceIDs[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State, options ...state.ListOption) []resource.ID {
+	return ResourceIDsWithOwner[R](ctx, t, st, nil, options...)
+}

--- a/pkg/resource/rtestutils/rtestutils.go
+++ b/pkg/resource/rtestutils/rtestutils.go
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package rtestutils provides utilities for testing with resource API.
+package rtestutils
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+)
+
+// ResourceWithRD is a resource providing resource definition.
+type ResourceWithRD interface {
+	resource.Resource
+	meta.ResourceDefinitionProvider
+}


### PR DESCRIPTION
This type of controller transforms (or maps) resources of one type into resources of another type. Transformation function might have side effects which provide the additional feature.

Also additional inputs might be used to facilitate the transformation process.

Controller provides the necessary boilterplate to handle all flows with finalizers and teardown flow.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>