### PR TITLE
feat: add support for no protobuf unmarshaling via gRPC

### DIFF
--- a/pkg/controller/generic/transform/transform_test.go
+++ b/pkg/controller/generic/transform/transform_test.go
@@ -172,10 +172,10 @@ func TestDestroy(t *testing.T) {
 		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-1")
 		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
 
-		_, err := st.Teardown(ctx, NewA("3", ASpec{}).Metadata())
+		ready, err := st.Teardown(ctx, NewA("3", ASpec{}).Metadata())
 		require.NoError(t, err)
 
-		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2", "transformed-3"}, func(r *B, assert *assert.Assertions) {})
+		assert.True(t, ready)
 
 		require.NoError(t, st.Destroy(ctx, NewA("3", ASpec{}).Metadata()))
 

--- a/pkg/state/options.go
+++ b/pkg/state/options.go
@@ -7,15 +7,30 @@ package state
 import "github.com/cosi-project/runtime/pkg/resource"
 
 // GetOptions for the CoreState.Get function.
-type GetOptions struct{}
+type GetOptions struct {
+	UnmarshalOptions UnmarshalOptions
+}
 
 // GetOption builds GetOptions.
 type GetOption func(*GetOptions)
 
+// WithGetUnmarshalOptions sets unmarshal options for Get API.
+func WithGetUnmarshalOptions(opt ...UnmarshalOption) GetOption {
+	return func(opts *GetOptions) {
+		for _, o := range opt {
+			o(&opts.UnmarshalOptions)
+		}
+	}
+}
+
 // ListOptions for the CoreState.List function.
 type ListOptions struct {
-	LabelQuery resource.LabelQuery
+	LabelQuery       resource.LabelQuery
+	UnmarshalOptions UnmarshalOptions
 }
+
+// ListOption builds ListOptions.
+type ListOption func(*ListOptions)
 
 // WithLabelQuery appends a label query to the list options.
 func WithLabelQuery(opt ...resource.LabelQueryOption) ListOption {
@@ -26,8 +41,14 @@ func WithLabelQuery(opt ...resource.LabelQueryOption) ListOption {
 	}
 }
 
-// ListOption builds ListOptions.
-type ListOption func(*ListOptions)
+// WithListUnmarshalOptions sets unmarshal options for List API.
+func WithListUnmarshalOptions(opt ...UnmarshalOption) ListOption {
+	return func(opts *ListOptions) {
+		for _, o := range opt {
+			o(&opts.UnmarshalOptions)
+		}
+	}
+}
 
 // CreateOptions for the CoreState.Create function.
 type CreateOptions struct {
@@ -119,7 +140,8 @@ func WithDestroyOwner(owner string) DestroyOption {
 
 // WatchOptions for the CoreState.Watch function.
 type WatchOptions struct {
-	TailEvents int
+	TailEvents       int
+	UnmarshalOptions UnmarshalOptions
 }
 
 // WatchOption builds WatchOptions.
@@ -132,9 +154,19 @@ func WithTailEvents(n int) WatchOption {
 	}
 }
 
+// WithWatchUnmarshalOptions sets unmarshal options for Watch API.
+func WithWatchUnmarshalOptions(opt ...UnmarshalOption) WatchOption {
+	return func(opts *WatchOptions) {
+		for _, o := range opt {
+			o(&opts.UnmarshalOptions)
+		}
+	}
+}
+
 // WatchKindOptions for the CoreState.WatchKind function.
 type WatchKindOptions struct {
 	LabelQuery        resource.LabelQuery
+	UnmarshalOptions  UnmarshalOptions
 	BootstrapContents bool
 	TailEvents        int
 }
@@ -156,11 +188,37 @@ func WithKindTailEvents(n int) WatchKindOption {
 	}
 }
 
+// WithWatchKindUnmarshalOptions sets unmarshal options for WatchKind API.
+func WithWatchKindUnmarshalOptions(opt ...UnmarshalOption) WatchKindOption {
+	return func(opts *WatchKindOptions) {
+		for _, o := range opt {
+			o(&opts.UnmarshalOptions)
+		}
+	}
+}
+
 // WatchWithLabelQuery appends a label query to the list options.
 func WatchWithLabelQuery(opt ...resource.LabelQueryOption) WatchKindOption {
 	return func(opts *WatchKindOptions) {
 		for _, o := range opt {
 			o(&opts.LabelQuery)
 		}
+	}
+}
+
+// UnmarshalOptions control resources marshaling/unmarshaling.
+type UnmarshalOptions struct {
+	SkipProtobufUnmarshal bool
+}
+
+// UnmarshalOption builds MarshalOptions.
+type UnmarshalOption func(*UnmarshalOptions)
+
+// WithSkipProtobufUnmarshal skips full unmarshaling returning a generic wrapper.
+//
+// This options preservers original YAML representation.
+func WithSkipProtobufUnmarshal() UnmarshalOption {
+	return func(opts *UnmarshalOptions) {
+		opts.SkipProtobufUnmarshal = true
 	}
 }

--- a/pkg/state/protobuf/client/client_test.go
+++ b/pkg/state/protobuf/client/client_test.go
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/cosi-project/runtime/api/v1alpha1"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/conformance"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/protobuf/client"
+	"github.com/cosi-project/runtime/pkg/state/protobuf/server"
+)
+
+func TestProtobufSkipUnmarshal(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	sock, err := os.CreateTemp("", "api*.sock")
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(sock.Name()))
+
+	defer os.Remove(sock.Name()) //nolint:errcheck
+
+	l, err := net.Listen("unix", sock.Name())
+	require.NoError(t, err)
+
+	memState := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	grpcServer := grpc.NewServer()
+	v1alpha1.RegisterStateServer(grpcServer, server.NewState(memState))
+
+	go func() {
+		grpcServer.Serve(l) //nolint:errcheck
+	}()
+
+	defer grpcServer.Stop()
+
+	grpcConn, err := grpc.Dial("unix://"+sock.Name(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	defer grpcConn.Close() //nolint:errcheck
+
+	stateClient := v1alpha1.NewStateClient(grpcConn)
+
+	require.NoError(t, protobuf.RegisterResource(conformance.PathResourceType, &conformance.PathResource{}))
+
+	grpcState := state.WrapCore(client.NewAdapter(stateClient))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// put a couple of resources directly to in-memory state
+	path1 := conformance.NewPathResource("1", "/path/1")
+	path2 := conformance.NewPathResource("2", "/path/2")
+
+	for _, r := range []resource.Resource{path1, path2} {
+		require.NoError(t, memState.Create(ctx, r))
+	}
+
+	// get without unmarshal
+	any1, err := grpcState.Get(ctx, path1.Metadata(), state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()))
+	require.NoError(t, err)
+
+	assert.True(t, path1.Metadata().Equal(*any1.Metadata()))
+	assert.IsType(t, &protobuf.Resource{}, any1)
+
+	// get with unmarshal
+	any2, err := grpcState.Get(ctx, path2.Metadata())
+	require.NoError(t, err)
+
+	assert.True(t, path2.Metadata().Equal(*any2.Metadata()))
+	assert.IsType(t, &conformance.PathResource{}, any2)
+
+	// list without unmarshal
+	anyList, err := grpcState.List(ctx, path1.Metadata(), state.WithListUnmarshalOptions(state.WithSkipProtobufUnmarshal()))
+	require.NoError(t, err)
+
+	assert.Len(t, anyList.Items, 1)
+	assert.True(t, path1.Metadata().Equal(*anyList.Items[0].Metadata()))
+	assert.IsType(t, &protobuf.Resource{}, anyList.Items[0])
+
+	// watch
+	ch := make(chan state.Event)
+
+	require.NoError(t, grpcState.Watch(ctx, path1.Metadata(), ch, state.WithWatchUnmarshalOptions(state.WithSkipProtobufUnmarshal())))
+
+	var ev state.Event
+
+	select {
+	case ev = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	assert.Equal(t, state.Created, ev.Type)
+	assert.True(t, path1.Metadata().Equal(*ev.Resource.Metadata()))
+	assert.IsType(t, &protobuf.Resource{}, ev.Resource)
+
+	require.NoError(t, grpcState.WatchKind(ctx, path1.Metadata(), ch,
+		state.WithBootstrapContents(true),
+		state.WithWatchKindUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+	))
+
+	select {
+	case ev = <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	assert.Equal(t, state.Created, ev.Type)
+	assert.True(t, path1.Metadata().Equal(*ev.Resource.Metadata()))
+	assert.IsType(t, &protobuf.Resource{}, ev.Resource)
+}


### PR DESCRIPTION
This allows to skip full protobuf unmarshaling and preserve the original YAML representation which is sometimes helpful when there's a goal to preserve compatibility with the server when proto definitions are not in sync.

E.g. getting only YAML representation of a resource which is not known to the client, or some fields are not supported by the client yet.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>