### PR TITLE
fix: update with conflicts should return new resource

### DIFF
--- a/pkg/controller/conformance/runtime.go
+++ b/pkg/controller/conformance/runtime.go
@@ -246,12 +246,13 @@ func (suite *RuntimeSuite) TestIntToStrToSentenceControllers() {
 		resource.Resource
 	}
 
-	_, err := safe.StateUpdateWithConflicts[integerResource](suite.ctx, suite.State, one.Metadata(), func(r integerResource) error {
+	eleven, err := safe.StateUpdateWithConflicts[integerResource](suite.ctx, suite.State, one.Metadata(), func(r integerResource) error {
 		r.SetValue(11)
 
 		return nil
 	})
 	suite.Assert().NoError(err)
+	suite.Assert().Equal(11, eleven.Value())
 
 	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(10*time.Millisecond)).
 		Retry(suite.assertStrObjects("sentences", SentenceResourceType, []string{"one", "two", "three"}, []string{"11 sentence", "2 sentence", "3 sentence"})))

--- a/pkg/state/wrap.go
+++ b/pkg/state/wrap.go
@@ -47,12 +47,12 @@ func (state coreWrapper) UpdateWithConflicts(ctx context.Context, resourcePointe
 		}
 
 		if resource.Equal(current, newResource) {
-			return current, nil
+			return newResource, nil
 		}
 
 		err = state.Update(ctx, newResource, opts...)
 		if err == nil {
-			return current, nil
+			return newResource, nil
 		}
 
 		if IsConflictError(err) && !IsOwnerConflictError(err) && !IsPhaseConflictError(err) {


### PR DESCRIPTION
This fixes a bug which is at least 22 months old (from the initial implementation).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>