### PR TITLE
feat: provide an option to limit inputs for TransformController

### DIFF
--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -196,7 +196,7 @@ func (ctrl *Controller[Input, Output]) processInputs(
 	runState *runState,
 	inputMetadata resource.Metadata,
 ) error {
-	inputItems, err := safe.ReaderList[Input](ctx, r, inputMetadata)
+	inputItems, err := safe.ReaderList[Input](ctx, r, inputMetadata, ctrl.options.inputListOptions...)
 	if err != nil {
 		return fmt.Errorf("error listing input resources: %w", err)
 	}

--- a/pkg/controller/generic/transform/options.go
+++ b/pkg/controller/generic/transform/options.go
@@ -4,16 +4,29 @@
 
 package transform
 
-import "github.com/cosi-project/runtime/pkg/controller"
+import (
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/state"
+)
 
 // ControllerOptions configures TransformController.
 type ControllerOptions struct {
-	extraInputs     []controller.Input
-	inputFinalizers bool
+	inputListOptions []state.ListOption
+	extraInputs      []controller.Input
+	inputFinalizers  bool
 }
 
 // ControllerOption is an option for TransformController.
 type ControllerOption func(*ControllerOptions)
+
+// WithInputListOptions adds an filter on input resource list.
+//
+// E.g. query only resources with specific labels.
+func WithInputListOptions(opts ...state.ListOption) ControllerOption {
+	return func(o *ControllerOptions) {
+		o.inputListOptions = append(o.inputListOptions, opts...)
+	}
+}
 
 // WithExtraInputs adds extra inputs to the controller.
 func WithExtraInputs(inputs ...controller.Input) ControllerOption {


### PR DESCRIPTION
This allows e.g. to transform only subset of inputs by labels.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>