### PR TITLE
chore: add `YAMLResource` resource wrapper

### DIFF
--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -115,6 +115,11 @@ owner:
 phase: running
 `+timestamps, string(out))
 
+	var in resource.Metadata
+
+	assert.NoError(t, yaml.Unmarshal(out, &in))
+	assert.True(t, md.Equal(in))
+
 	md.Finalizers().Add("\"resource1")
 	md.Finalizers().Add("resource2")
 	assert.NoError(t, md.SetOwner("FooController"))
@@ -131,6 +136,8 @@ phase: running
     - '"resource1'
     - resource2
 `, string(out))
+	assert.NoError(t, yaml.Unmarshal(out, &in))
+	assert.True(t, md.Equal(in))
 
 	md.Labels().Set("stage", "initial")
 	md.Labels().Set("app", "foo")
@@ -150,6 +157,9 @@ finalizers:
     - '"resource1'
     - resource2
 `, string(out))
+
+	assert.NoError(t, yaml.Unmarshal(out, &in))
+	assert.True(t, md.Equal(in))
 
 	md.Annotations().Set("dependencies", "abcdef")
 	md.Annotations().Set("ttl", "1h")
@@ -172,6 +182,9 @@ finalizers:
     - '"resource1'
     - resource2
 `, string(out))
+
+	assert.NoError(t, yaml.Unmarshal(out, &in))
+	assert.True(t, md.Equal(in))
 }
 
 var ts, _ = time.Parse(time.RFC3339, "2021-06-23T19:22:29Z")

--- a/pkg/resource/protobuf/yaml.go
+++ b/pkg/resource/protobuf/yaml.go
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package protobuf
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+)
+
+// YAMLResource is a wrapper around Resource which implements yaml.Unmarshaler.
+// Its here and not in resource package to avoid circular dependency.
+type YAMLResource struct {
+	r resource.Resource
+}
+
+// Resource returns the underlying resource.
+func (r *YAMLResource) Resource() resource.Resource {
+	if r.r == nil {
+		panic("resource is not set")
+	}
+
+	return r.r.DeepCopy()
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (r *YAMLResource) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping node, got %d", value.Kind)
+	}
+
+	if len(value.Content) != 4 {
+		return fmt.Errorf("expected 4 elements node, got %d", len(value.Content))
+	}
+
+	var mdNode, specNode *yaml.Node
+
+	for i := 0; i < len(value.Content); i += 2 {
+		key := value.Content[i]
+		val := value.Content[i+1]
+
+		if key.Kind != yaml.ScalarNode {
+			return fmt.Errorf("expected scalar node, got %d", key.Kind)
+		}
+
+		if val.Kind != yaml.MappingNode {
+			return fmt.Errorf("expected mapping node, got %d", value.Content[i+1].Kind)
+		}
+
+		switch key.Value {
+		case "metadata":
+			mdNode = val
+		case "spec":
+			specNode = val
+		default:
+			return fmt.Errorf("unexpected key %v", key)
+		}
+	}
+
+	if mdNode == nil || specNode == nil {
+		return fmt.Errorf("metadata or spec node is missing")
+	}
+
+	var md resource.Metadata
+
+	err := md.UnmarshalYAML(mdNode)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+
+	result, err := CreateResource(md.Type())
+	if err != nil {
+		return fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	*result.Metadata() = md
+
+	err = specNode.Decode(result.Spec())
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal spec: %w", err)
+	}
+
+	r.r = result
+
+	return nil
+}

--- a/pkg/resource/protobuf/yaml_test.go
+++ b/pkg/resource/protobuf/yaml_test.go
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package protobuf_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/go-pointer"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cosi-project/runtime/api/v1alpha1"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+)
+
+func init() {
+	err := protobuf.RegisterResource(TestType, &TestResource{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// TestNamespaceName is the namespace of Test resource.
+const TestNamespaceName = resource.Namespace("ns-event")
+
+// TestType is the type of Test.
+const TestType = resource.Type("Test.test.cosi.dev")
+
+type (
+	// TestResource is a test resource.
+	TestResource = typed.Resource[TestSpec, TestRD]
+)
+
+// NewTestResource initializes TestResource resource.
+func NewTestResource(id resource.ID, spec TestSpec) *TestResource {
+	return typed.NewResource[TestSpec, TestRD](
+		resource.NewMetadata(TestNamespaceName, TestType, id, resource.VersionUndefined),
+		spec,
+	)
+}
+
+// TestRD provides auxiliary methods for A.
+type TestRD struct{}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (TestRD) ResourceDefinition(_ resource.Metadata, _ TestSpec) meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             TestType,
+		DefaultNamespace: TestNamespaceName,
+	}
+}
+
+type TestSpec = protobuf.ResourceSpec[v1alpha1.UpdateOptions, *v1alpha1.UpdateOptions]
+
+func TestYAMLResource(t *testing.T) {
+	original := NewTestResource("id", TestSpec{
+		Value: &v1alpha1.UpdateOptions{
+			Owner:         "some owner",
+			ExpectedPhase: pointer.To(resource.Phase(0).String()),
+		},
+	})
+
+	strct, err := resource.MarshalYAML(original)
+	require.NoError(t, err)
+
+	raw, err := yaml.Marshal(strct)
+	require.NoError(t, err)
+
+	var result protobuf.YAMLResource
+
+	err = yaml.Unmarshal(raw, &result)
+	require.NoError(t, err)
+	require.True(t, resource.Equal(original, result.Resource()))
+}


### PR DESCRIPTION
Adds the special wrapper type - `YAMLResource` which is used to create resources from their YAML representation. Those resources should be registered with `protobuf.RegisterResource`.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>