### PR TITLE
chore: add `SetCreated` to `resource.Metadata`

### DIFF
--- a/pkg/resource/metadata.go
+++ b/pkg/resource/metadata.go
@@ -85,6 +85,11 @@ func (md *Metadata) SetVersion(newVersion Version) {
 	md.ver = newVersion
 }
 
+// SetCreated sets the resource create timestamp.
+func (md *Metadata) SetCreated(t time.Time) {
+	md.created = t
+}
+
 // SetUpdated sets the resource update timestamp.
 func (md *Metadata) SetUpdated(t time.Time) {
 	md.updated = t

--- a/pkg/state/impl/inmem/backing_store_test.go
+++ b/pkg/state/impl/inmem/backing_store_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,4 +107,16 @@ func TestBackingStore(t *testing.T) {
 	r, err = st.Get(ctx, path2.Metadata())
 	require.NoError(t, err)
 	assert.Equal(t, resource.String(path2), resource.String(r))
+
+	// ensure that resources always preserve creation time
+	cpy := r.DeepCopy()
+	cpy.Metadata().SetCreated(time.Time{})
+
+	require.NoError(t, st.Update(ctx, cpy))
+
+	got, err := st.Get(ctx, cpy.Metadata())
+	require.NoError(t, err)
+	require.NotZero(t, got.Metadata().Created())
+
+	assert.Equal(t, r.Metadata().Created(), got.Metadata().Created())
 }


### PR DESCRIPTION
Since we now have a way to create resources from their YAML representation, we want to ensure that invariants hold. For this commit we ensure that metadata creation date is always set, and cannot be overridden even on `Update`.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>