### PR TITLE
feat: add ResetRestartBackoff method to the controller adapter

### DIFF
--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -186,6 +186,8 @@ func (ctrl *Controller[Input, Output]) Run(ctx context.Context, r controller.Run
 		if err := state.multiErr.ErrorOrNil(); err != nil {
 			return err
 		}
+
+		r.ResetRestartBackoff()
 	}
 }
 

--- a/pkg/controller/protobuf/client/client.go
+++ b/pkg/controller/protobuf/client/client.go
@@ -341,6 +341,10 @@ func (ctrlAdapter *controllerAdapter) QueueReconcile() {
 	}
 }
 
+func (ctrlAdapter *controllerAdapter) ResetRestartBackoff() {
+	ctrlAdapter.backoff.Reset()
+}
+
 func (ctrlAdapter *controllerAdapter) UpdateInputs(inputs []controller.Input) error {
 	_, err := ctrlAdapter.adapter.client.UpdateInputs(ctrlAdapter.ctx, &v1alpha1.UpdateInputsRequest{
 		ControllerToken: ctrlAdapter.token,

--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -18,6 +18,7 @@ type ReconcileEvent struct{}
 type Runtime interface {
 	EventCh() <-chan ReconcileEvent
 	QueueReconcile()
+	ResetRestartBackoff()
 
 	UpdateInputs([]Input) error
 

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -56,6 +56,11 @@ func (adapter *adapter) QueueReconcile() {
 	adapter.triggerReconcile()
 }
 
+// ResetRestartBaooff implements controller.Runtime interface.
+func (adapter *adapter) ResetRestartBackoff() {
+	adapter.backoff.Reset()
+}
+
 // UpdateDependencies implements controller.Runtime interface.
 func (adapter *adapter) UpdateInputs(deps []controller.Input) error {
 	sort.Slice(deps, func(i, j int) bool {


### PR DESCRIPTION
This allows controller to say that it finished the reconcile loop without errors, so the restart backoff can be reset back to the initial value.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>