### PR TITLE
chore: redo YAML `inline` as MarshalYAML/UnmarshalYAML instead of the field tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-11-25T18:59:30Z by kres 3ac53a8.
+# Generated on 2022-12-08T20:30:31Z by kres latest.
 
 ARG TOOLCHAIN
 
-FROM ghcr.io/siderolabs/ca-certificates:v1.2.0 AS image-ca-certificates
+FROM ghcr.io/siderolabs/ca-certificates:v1.3.0 AS image-ca-certificates
 
-FROM ghcr.io/siderolabs/fhs:v1.2.0 AS image-fhs
+FROM ghcr.io/siderolabs/fhs:v1.3.0 AS image-fhs
 
 # runs markdownlint
-FROM docker.io/node:19.0.1-alpine3.16 AS lint-markdown
+FROM docker.io/node:19.2.0-alpine3.16 AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.32.2
 RUN npm i sentences-per-line@0.2.1


### PR DESCRIPTION
`yaml:",inline"` do not play well with custom types `MarshalYAML`, so for `ResourceSpec` we have to implement it manually.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>