### PR TITLE
feat: implement dynamic sizing of history buffer for in-mem resources

### DIFF
--- a/pkg/controller/runtime/runtime_test.go
+++ b/pkg/controller/runtime/runtime_test.go
@@ -46,7 +46,10 @@ func TestRuntimeWatchError(t *testing.T) {
 
 	// create a state with tiny capacity
 	st := state.WrapCore(namespaced.NewState(func(ns string) state.CoreState {
-		return inmem.NewStateWithOptions(inmem.WithHistoryCapacity(10), inmem.WithHistoryGap(5))(ns)
+		return inmem.NewStateWithOptions(
+			inmem.WithHistoryMaxCapacity(10),
+			inmem.WithHistoryGap(5),
+		)(ns)
 	}))
 
 	logger := zaptest.NewLogger(t)

--- a/pkg/state/impl/inmem/inmem.go
+++ b/pkg/state/impl/inmem/inmem.go
@@ -26,7 +26,7 @@ type State struct {
 	storeMu sync.Mutex
 	loaded  uint64
 
-	capacity, gap int
+	initialCapacity, maxCapacity, gap int
 }
 
 // NewState creates new State with default options.
@@ -42,10 +42,11 @@ func NewStateWithOptions(opts ...StateOption) func(ns resource.Namespace) *State
 
 	return func(ns resource.Namespace) *State {
 		return &State{
-			ns:       ns,
-			capacity: options.HistoryCapacity,
-			gap:      options.HistoryGap,
-			store:    options.BackingStore,
+			ns:              ns,
+			initialCapacity: options.HistoryInitialCapacity,
+			maxCapacity:     options.HistoryMaxCapacity,
+			gap:             options.HistoryGap,
+			store:           options.BackingStore,
 		}
 	}
 }
@@ -55,7 +56,7 @@ func (st *State) getCollection(typ resource.Type) *ResourceCollection {
 		return r.(*ResourceCollection) //nolint:forcetypeassert
 	}
 
-	collection := NewResourceCollection(st.ns, typ, st.capacity, st.gap, st.store)
+	collection := NewResourceCollection(st.ns, typ, st.initialCapacity, st.maxCapacity, st.gap, st.store)
 
 	r, _ := st.collections.LoadOrStore(typ, collection)
 


### PR DESCRIPTION
It's now possible to set initial/max capacity of the event buffer for in-memory resource collection. The defaults are still fixed 100 entries.

Allow to optionally set dynamic capacity of the history buffer, so that for resource types which are not updated frequently less memory is wasted for the allocated event stream, while frequently updated resources might benefit from a deeper history buffer.

This should help Talos, as it has 87 different resource types (and at least each resource has its own buffer), while some resources are updated frequently, while others are almost static. We can set dynamic capacity with smaller initial capacity which will grow on demand based on the number resources created/updated.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>