### PR TITLE
feat: implement controller runtime watch event deduplication

### DIFF
--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -44,7 +44,25 @@ type adapter struct {
 	watchFilterMu sync.Mutex
 }
 
-type watchFilter func(*resource.Metadata) bool
+type reducedMetadata struct {
+	namespace       resource.Namespace
+	typ             resource.Type
+	id              resource.ID
+	phase           resource.Phase
+	finalizersEmpty bool
+}
+
+func reduceMetadata(md *resource.Metadata) reducedMetadata {
+	return reducedMetadata{
+		namespace:       md.Namespace(),
+		typ:             md.Type(),
+		id:              md.ID(),
+		phase:           md.Phase(),
+		finalizersEmpty: md.Finalizers().Empty(),
+	}
+}
+
+type watchFilter func(*reducedMetadata) bool
 
 // EventCh implements controller.Runtime interface.
 func (adapter *adapter) EventCh() <-chan controller.ReconcileEvent {
@@ -341,12 +359,12 @@ func (adapter *adapter) deleteWatchFilter(resourceNamespace resource.Namespace, 
 	delete(adapter.watchFilters, watchKey{resourceNamespace, resourceType})
 }
 
-func (adapter *adapter) watchTrigger(md *resource.Metadata) {
+func (adapter *adapter) watchTrigger(md *reducedMetadata) {
 	adapter.watchFilterMu.Lock()
 	defer adapter.watchFilterMu.Unlock()
 
 	if adapter.watchFilters != nil {
-		if filter := adapter.watchFilters[watchKey{md.Namespace(), md.Type()}]; filter != nil && !filter(md) {
+		if filter := adapter.watchFilters[watchKey{md.namespace, md.typ}]; filter != nil && !filter(md) {
 			// skip reconcile if the event doesn't match the filter
 			return
 		}

--- a/pkg/controller/runtime/filter.go
+++ b/pkg/controller/runtime/filter.go
@@ -6,6 +6,6 @@ package runtime
 
 import "github.com/cosi-project/runtime/pkg/resource"
 
-func filterDestroyReady(md *resource.Metadata) bool {
-	return md.Phase() == resource.PhaseTearingDown && md.Finalizers().Empty()
+func filterDestroyReady(md *reducedMetadata) bool {
+	return md.phase == resource.PhaseTearingDown && md.finalizersEmpty
 }

--- a/pkg/controller/runtime/runtime.go
+++ b/pkg/controller/runtime/runtime.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/go-pointer"
 	"go.uber.org/zap"
 
@@ -48,13 +49,18 @@ type watchKey struct {
 	Type      resource.Type
 }
 
+// watchBuffer provides a buffer to aggregate multiple match events.
+//
+// this improves efficiency of a deduplication algorithm.
+const watchBuffer = 256
+
 // NewRuntime initializes controller runtime object.
 func NewRuntime(st state.State, logger *zap.Logger) (*Runtime, error) {
 	runtime := &Runtime{
 		state:       st,
 		logger:      logger,
 		controllers: make(map[string]*adapter),
-		watchCh:     make(chan state.Event),
+		watchCh:     make(chan state.Event, watchBuffer),
 		watchErrors: make(chan error, 1),
 		watched:     make(map[watchKey]struct{}),
 	}
@@ -234,10 +240,37 @@ func (runtime *Runtime) watch(resourceNamespace resource.Namespace, resourceType
 	return runtime.state.WatchKind(runtime.runCtx, kind, runtime.watchCh)
 }
 
+type dedup map[reducedMetadata]struct{}
+
 func (runtime *Runtime) processWatched() {
+	// Perform deduplication of events based on the reduction of the event value to the reducedMetadata.
+	//
+	// deduplication process consists of two goroutines:
+	// 1. the first goroutine reads events from the watch channel as fast as possible,
+	//    reduces the event value to 'reducedMetadata' and pushes them to the map
+	// 2. the second goroutine consumes a map from the first goroutine, performs the work required
+	//    to trigger updates in the dependent controller
+	//
+	// The design idea is to consume watch events as fast as possible, while delaying "heavy" work
+	// to the second goroutine.
+	//
+	// There is a trick being used which sends a single map back and forth between the two goroutines.
+	// There is no locking required, as the map is owned by a single goroutine at a single moment of time.
+	// Additional channel 'empty' is used to block the second goroutine when there are no events to process.
+	ch := make(chan dedup, 1)
+	empty := make(chan dedup, 1)
+	empty <- dedup{}
+
+	go runtime.deduplicateWatchEvents(ch, empty)
+	go runtime.deliverDeduplicatedEvents(ch, empty)
+}
+
+// deduplicateWatchEvents deduplicates events from the watch channel into the map sent to the channel ch.
+func (runtime *Runtime) deduplicateWatchEvents(ch chan dedup, empty <-chan dedup) {
 	for {
 		var e state.Event
 
+		// wait for an event
 		select {
 		case <-runtime.runCtx.Done():
 			return
@@ -251,12 +284,81 @@ func (runtime *Runtime) processWatched() {
 			return
 		}
 
-		md := e.Resource.Metadata()
+		// acquire a map
+		var m dedup
 
+		select {
+		case m = <-empty:
+		case m = <-ch:
+		case <-runtime.runCtx.Done():
+			return
+		}
+
+		m[reduceMetadata(e.Resource.Metadata())] = struct{}{}
+
+		// drain the watchCh by consuming all immediately available events
+	drainer:
+		for {
+			select {
+			case e = <-runtime.watchCh:
+				if e.Type == state.Errored {
+					// watch failed, we need to abort
+					runtime.watchErrors <- e.Error
+
+					return
+				}
+
+				m[reduceMetadata(e.Resource.Metadata())] = struct{}{}
+			case <-runtime.runCtx.Done():
+				return
+			default:
+				break drainer
+			}
+		}
+
+		// send the map to the second goroutine for processing
+		if !channel.SendWithContext(runtime.runCtx, ch, m) {
+			return
+		}
+	}
+}
+
+// deliverDeduplicatedEvents delivers events from the deduplicated channel to the controllers.
+func (runtime *Runtime) deliverDeduplicatedEvents(ch chan dedup, empty chan<- dedup) {
+	for {
+		// wait for a map
+		var m dedup
+		select {
+		case m = <-ch:
+		case <-runtime.runCtx.Done():
+			return
+		}
+
+		// consume any first key of the map
+		var k reducedMetadata
+
+		for k = range m {
+			break
+		}
+
+		delete(m, k)
+
+		// send the map back to the first goroutine
+		if len(m) > 0 {
+			if !channel.SendWithContext(runtime.runCtx, ch, m) {
+				return
+			}
+		} else {
+			if !channel.SendWithContext(runtime.runCtx, empty, m) {
+				return
+			}
+		}
+
+		// notify controllers
 		controllers, err := runtime.depDB.GetDependentControllers(controller.Input{
-			Namespace: md.Namespace(),
-			Type:      md.Type(),
-			ID:        pointer.To(md.ID()),
+			Namespace: k.namespace,
+			Type:      k.typ,
+			ID:        pointer.To(k.id),
 		})
 		if err != nil {
 			// TODO: no way to handle it here
@@ -266,7 +368,7 @@ func (runtime *Runtime) processWatched() {
 		runtime.controllersMu.RLock()
 
 		for _, ctrl := range controllers {
-			runtime.controllers[ctrl].watchTrigger(md)
+			runtime.controllers[ctrl].watchTrigger(&k)
 		}
 
 		runtime.controllersMu.RUnlock()


### PR DESCRIPTION
Under a burst of events related to small number of resources, deduper might aggregate several watch events into smaller number of final updates which trigger controller updates.

Co-authored-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>