### PR TITLE
feat: add Set/Has methods to finalizers

### DIFF
--- a/pkg/resource/finalizer.go
+++ b/pkg/resource/finalizer.go
@@ -46,3 +46,26 @@ func (fins *Finalizers) Remove(fin Finalizer) bool {
 func (fins Finalizers) Empty() bool {
 	return len(fins) == 0
 }
+
+// Has returns true if fin is present in the list of finalizers.
+func (fins Finalizers) Has(fin Finalizer) bool {
+	for _, f := range fins {
+		if f == fin {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Set copies the finalizers from the other.
+func (fins *Finalizers) Set(other Finalizers) {
+	if other == nil {
+		*fins = nil
+
+		return
+	}
+
+	*fins = make([]Finalizer, len(other))
+	copy(*fins, other)
+}

--- a/pkg/resource/finalizer_test.go
+++ b/pkg/resource/finalizer_test.go
@@ -32,16 +32,33 @@ func TestFinalizers(t *testing.T) {
 
 	assert.True(t, fins.Add(B))
 	assert.False(t, fins.Add(B))
+	assert.True(t, fins.Has(B))
+	assert.False(t, fins.Has(C))
 
 	assert.True(t, finsCopy.Add(B))
 
 	assert.False(t, fins.Remove(C))
 	assert.True(t, fins.Remove(B))
 	assert.False(t, fins.Remove(B))
+	assert.False(t, fins.Has(B))
+	assert.False(t, fins.Has(C))
 
 	finsCopy = fins
 
 	assert.True(t, finsCopy.Add(C))
 	assert.True(t, fins.Add(C))
 	assert.True(t, fins.Remove(C))
+
+	fins = nil
+
+	finsCopy.Set(fins)
+	assert.True(t, finsCopy.Empty())
+	assert.Nil(t, finsCopy)
+
+	assert.True(t, fins.Add(A))
+	assert.True(t, fins.Add(C))
+
+	finsCopy.Set(fins)
+	assert.True(t, finsCopy.Has(A))
+	assert.True(t, finsCopy.Has(C))
 }


### PR DESCRIPTION
Has was missing, and causing lots of trouble.

Set method allows to copy finalizers from one resource to another.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>