### PR TITLE
backport: fix: restart controllers on panic

### DIFF
--- a/pkg/controller/conformance/controllers.go
+++ b/pkg/controller/conformance/controllers.go
@@ -300,6 +300,7 @@ func (ctrl *SumController) Run(ctx context.Context, r controller.Runtime, logger
 // FailingController fails on each iteration creating new resources each time.
 type FailingController struct {
 	TargetNamespace resource.Namespace
+	Panic           bool
 
 	count int
 }
@@ -341,6 +342,10 @@ func (ctrl *FailingController) Run(ctx context.Context, r controller.Runtime, lo
 	}
 
 	ctrl.count++
+
+	if ctrl.Panic {
+		panic("failing here")
+	}
 
 	return fmt.Errorf("failing here")
 }

--- a/pkg/controller/conformance/runtime.go
+++ b/pkg/controller/conformance/runtime.go
@@ -400,3 +400,19 @@ func (suite *RuntimeSuite) TestFailingController() {
 	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(10*time.Millisecond)).
 		Retry(suite.assertIntObjects([]string{"0", "1"}, []int{0, 1})))
 }
+
+// TestPanickingController ...
+func (suite *RuntimeSuite) TestPanickingController() {
+	suite.Require().NoError(suite.Runtime.RegisterController(&FailingController{
+		TargetNamespace: "target",
+		Panic:           true,
+	}))
+
+	suite.startRuntime()
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(10*time.Millisecond)).
+		Retry(suite.assertIntObjects([]string{"0"}, []int{0})))
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(10*time.Millisecond)).
+		Retry(suite.assertIntObjects([]string{"0", "1"}, []int{0, 1})))
+}

--- a/pkg/controller/protobuf/client/client.go
+++ b/pkg/controller/protobuf/client/client.go
@@ -252,9 +252,7 @@ func (ctrlAdapter *controllerAdapter) run(ctx context.Context) {
 	}
 }
 
-func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.Logger) error {
-	var err error
-
+func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.Logger) (err error) {
 	defer func() {
 		if err != nil && (errors.Is(err, context.Canceled) || status.Code(errors.Unwrap(err)) == codes.Canceled) {
 			err = nil
@@ -275,9 +273,7 @@ func (ctrlAdapter *controllerAdapter) runOnce(ctx context.Context, logger *zap.L
 
 	logger.Debug("controller starting")
 
-	err = ctrlAdapter.controller.Run(ctx, ctrlAdapter, logger)
-
-	return err
+	return ctrlAdapter.controller.Run(ctx, ctrlAdapter, logger)
 }
 
 func (ctrlAdapter *controllerAdapter) establishEventChannel() {

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -383,9 +383,7 @@ func (adapter *adapter) run(ctx context.Context) {
 	}
 }
 
-func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) error {
-	var err error
-
+func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) (err error) {
 	defer func() {
 		if err != nil && errors.Is(err, context.Canceled) {
 			err = nil
@@ -406,7 +404,5 @@ func (adapter *adapter) runOnce(ctx context.Context, logger *zap.Logger) error {
 
 	logger.Debug("controller starting")
 
-	err = adapter.ctrl.Run(ctx, adapter, logger)
-
-	return err
+	return adapter.ctrl.Run(ctx, adapter, logger)
 }


### PR DESCRIPTION
This feature got broken in 1ed3207ee2808e35ea0f3a6ddbe149ed7e90223b, as named return was replaced with a variable which doesn't work to override return value in defer blocks.

In case of panic, panic was intercepted correctly, but still `nil` was returned, as panic was handled. And `nil` return means "don't restart" which stops automatic controller restarts.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit 62c39680d91b09d457e4c3a345e238e744cb6799)