### PR TITLE
feat: allow transform controller to ignore tearing down inputs

### DIFF
--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -209,7 +209,7 @@ func (ctrl *Controller[Input, Output]) processInputs(
 
 		mappedOut := ctrl.mapFunc(in)
 
-		if in.Metadata().Phase() == resource.PhaseTearingDown {
+		if !ctrl.options.ignoreTearingDownInputs && in.Metadata().Phase() == resource.PhaseTearingDown {
 			ctrl.reconcileTearingDownInput(ctx, r, logger, runState, in, mappedOut)
 
 			// skip normal reconciliation
@@ -217,6 +217,7 @@ func (ctrl *Controller[Input, Output]) processInputs(
 		}
 
 		// in this part of the function input resource is in PhaseRunning
+		// (or tearing down inputs are ignored with ignoreTearingDownInputs option, but in this case inputFinalizers are disabled)
 		runState.touchedOutputIDs[mappedOut.Metadata().ID()] = struct{}{}
 
 		// if the input finalizers are enabled, set the finalizer on input asap

--- a/pkg/controller/generic/transform/options.go
+++ b/pkg/controller/generic/transform/options.go
@@ -11,9 +11,10 @@ import (
 
 // ControllerOptions configures TransformController.
 type ControllerOptions struct {
-	inputListOptions []state.ListOption
-	extraInputs      []controller.Input
-	inputFinalizers  bool
+	inputListOptions        []state.ListOption
+	extraInputs             []controller.Input
+	inputFinalizers         bool
+	ignoreTearingDownInputs bool
 }
 
 // ControllerOption is an option for TransformController.
@@ -40,6 +41,24 @@ func WithExtraInputs(inputs ...controller.Input) ControllerOption {
 // The finalizer on input will be removed only when matching output is destroyed.
 func WithInputFinalizers() ControllerOption {
 	return func(o *ControllerOptions) {
+		if o.ignoreTearingDownInputs {
+			panic("WithIgnoreTearingDownInputs is mutually exclusive with WithInputFinalizers")
+		}
+
 		o.inputFinalizers = true
+	}
+}
+
+// WithIgnoreTearingDownInputs makes controller treat tearing down inputs as 'normal' inputs.
+//
+// With this setting enabled outputs will still exist until the input is destroyed.
+// This setting is mutually exclusive with WithInputFinalizers.
+func WithIgnoreTearingDownInputs() ControllerOption {
+	return func(o *ControllerOptions) {
+		if o.inputFinalizers {
+			panic("WithIgnoreTearingDownInputs is mutually exclusive with WithInputFinalizers")
+		}
+
+		o.ignoreTearingDownInputs = true
 	}
 }


### PR DESCRIPTION
This is sometimes useful for `Resource` -> `ResourceStatus` when the status resource should exist as long as the input resource exists, even if it's being torn down.

This only works if the controller doesn't set finalizers on its input, as otherwise it breaks the logic: if the finalizer is set, output should be destroyed before the input.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>