### PR TITLE
chore: extension methods for typed.Resource, simplify ResourceDefinition

### DIFF
--- a/pkg/controller/generic/transform/resource_test.go
+++ b/pkg/controller/generic/transform/resource_test.go
@@ -17,21 +17,21 @@ const ANamespaceName = resource.Namespace("ns-a")
 const AType = resource.Type("A.test.cosi.dev")
 
 // A is a test resource.
-type A = typed.Resource[ASpec, ARD]
+type A = typed.Resource[ASpec, AE]
 
 // NewA initializes a A resource.
 func NewA(id resource.ID, spec ASpec) *A {
-	return typed.NewResource[ASpec, ARD](
+	return typed.NewResource[ASpec, AE](
 		resource.NewMetadata(ANamespaceName, AType, id, resource.VersionUndefined),
 		spec,
 	)
 }
 
-// ARD provides auxiliary methods for A.
-type ARD struct{}
+// AE provides auxiliary methods for A.
+type AE struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (ARD) ResourceDefinition(_ resource.Metadata, _ ASpec) meta.ResourceDefinitionSpec {
+func (AE) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             AType,
 		DefaultNamespace: ANamespaceName,
@@ -56,21 +56,21 @@ const BNamespaceName = resource.Namespace("ns-b")
 const BType = resource.Type("B.test.cosi.dev")
 
 // B is a test resource.
-type B = typed.Resource[BSpec, BRD]
+type B = typed.Resource[BSpec, BE]
 
 // NewB initializes a B resource.
 func NewB(id resource.ID, spec BSpec) *B {
-	return typed.NewResource[BSpec, BRD](
+	return typed.NewResource[BSpec, BE](
 		resource.NewMetadata(BNamespaceName, BType, id, resource.VersionUndefined),
 		spec,
 	)
 }
 
-// BRD provides auxiliary methods for B.
-type BRD struct{}
+// BE provides auxiliary methods for B.
+type BE struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (BRD) ResourceDefinition(_ resource.Metadata, _ BSpec) meta.ResourceDefinitionSpec {
+func (BE) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             BType,
 		DefaultNamespace: BNamespaceName,

--- a/pkg/resource/meta/namespace.go
+++ b/pkg/resource/meta/namespace.go
@@ -15,21 +15,21 @@ import (
 const NamespaceType = resource.Type("Namespaces.meta.cosi.dev")
 
 // Namespace provides metadata about namespaces.
-type Namespace = typed.Resource[NamespaceSpec, NamespaceRD]
+type Namespace = typed.Resource[NamespaceSpec, NamespaceExtension]
 
 // NewNamespace initializes a Namespace resource.
 func NewNamespace(id resource.ID, spec NamespaceSpec) *Namespace {
-	return typed.NewResource[NamespaceSpec, NamespaceRD](
+	return typed.NewResource[NamespaceSpec, NamespaceExtension](
 		resource.NewMetadata(NamespaceName, NamespaceType, id, resource.VersionUndefined),
 		spec,
 	)
 }
 
-// NamespaceRD provides auxiliary methods for Namespace.
-type NamespaceRD struct{}
+// NamespaceExtension provides auxiliary methods for Namespace.
+type NamespaceExtension struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (NamespaceRD) ResourceDefinition(_ resource.Metadata, _ NamespaceSpec) ResourceDefinitionSpec {
+func (NamespaceExtension) ResourceDefinition() ResourceDefinitionSpec {
 	return ResourceDefinitionSpec{
 		Type:             NamespaceType,
 		DefaultNamespace: NamespaceName,

--- a/pkg/resource/meta/resource_definition.go
+++ b/pkg/resource/meta/resource_definition.go
@@ -24,7 +24,7 @@ type (
 	ResourceDefinitionSpec = spec.ResourceDefinitionSpec
 
 	// ResourceDefinition provides metadata about namespaces.
-	ResourceDefinition = typed.Resource[ResourceDefinitionSpec, ResourceDefinitionRD]
+	ResourceDefinition = typed.Resource[ResourceDefinitionSpec, ResourceDefinitionExtension]
 )
 
 // NewResourceDefinition initializes a ResourceDefinition resource.
@@ -33,17 +33,17 @@ func NewResourceDefinition(spec ResourceDefinitionSpec) (*ResourceDefinition, er
 		return nil, fmt.Errorf("error validating resource definition %q: %w", spec.Type, err)
 	}
 
-	return typed.NewResource[ResourceDefinitionSpec, ResourceDefinitionRD](
+	return typed.NewResource[ResourceDefinitionSpec, ResourceDefinitionExtension](
 		resource.NewMetadata(NamespaceName, ResourceDefinitionType, spec.ID(), resource.VersionUndefined),
 		spec,
 	), nil
 }
 
-// ResourceDefinitionRD provides auxiliary methods for ResourceDefinition.
-type ResourceDefinitionRD struct{}
+// ResourceDefinitionExtension provides auxiliary methods for ResourceDefinition.
+type ResourceDefinitionExtension struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (ResourceDefinitionRD) ResourceDefinition(_ resource.Metadata, _ spec.ResourceDefinitionSpec) ResourceDefinitionSpec {
+func (ResourceDefinitionExtension) ResourceDefinition() ResourceDefinitionSpec {
 	return ResourceDefinitionSpec{
 		Type:             ResourceDefinitionType,
 		Aliases:          []resource.Type{"api-resources"},

--- a/pkg/resource/protobuf/spec_test.go
+++ b/pkg/resource/protobuf/spec_test.go
@@ -39,11 +39,11 @@ func TestResourceSpec(t *testing.T) {
 	require.True(t, protobuf.ProtoEqual(spec.Value, specDecoded.Value))
 }
 
-type testResource = typed.Resource[testSpec, testRD]
+type testResource = typed.Resource[testSpec, testExtension]
 
-type testRD struct{}
+type testExtension struct{}
 
-func (testRD) ResourceDefinition(resource.Metadata, testSpec) meta.ResourceDefinitionSpec {
+func (testExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type: "testResource",
 	}
@@ -52,11 +52,11 @@ func (testRD) ResourceDefinition(resource.Metadata, testSpec) meta.ResourceDefin
 func TestResourceEquality(t *testing.T) {
 	t.Parallel()
 
-	r1 := typed.NewResource[testSpec, testRD](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
+	r1 := typed.NewResource[testSpec, testExtension](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
 		Version: "v0.1.0",
 	}))
 
-	r2 := typed.NewResource[testSpec, testRD](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
+	r2 := typed.NewResource[testSpec, testExtension](resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined), protobuf.NewResourceSpec(&v1alpha1.Metadata{
 		Version: "v0.1.0",
 	}))
 
@@ -91,7 +91,7 @@ func TestResourceEquality(t *testing.T) {
 func TestDynamicResourceEquality(t *testing.T) {
 	t.Parallel()
 
-	r1 := typed.NewResource[ReflectSpec, ReflectSpecRD](
+	r1 := typed.NewResource[ReflectSpec, ReflectSpecExtension](
 		resource.NewMetadata("default", "reflectResource", "aaa", resource.VersionUndefined),
 		ReflectSpec{"test"})
 
@@ -118,7 +118,7 @@ func TestDynamicResourceEquality(t *testing.T) {
 	require.Equal(t, r1.Spec(), r3.Spec())
 }
 
-type reflectResource = typed.Resource[ReflectSpec, ReflectSpecRD]
+type reflectResource = typed.Resource[ReflectSpec, ReflectSpecExtension]
 
 type ReflectSpec struct {
 	Var string `protobuf:"1"`
@@ -128,9 +128,9 @@ func (t ReflectSpec) DeepCopy() ReflectSpec {
 	return t
 }
 
-type ReflectSpecRD struct{}
+type ReflectSpecExtension struct{}
 
-func (ReflectSpecRD) ResourceDefinition(resource.Metadata, ReflectSpec) meta.ResourceDefinitionSpec {
+func (ReflectSpecExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		DisplayType: "test definition",
 	}
@@ -138,16 +138,16 @@ func (ReflectSpecRD) ResourceDefinition(resource.Metadata, ReflectSpec) meta.Res
 
 type resourceDefinition = protobuf.ResourceSpec[v1alpha1.ResourceDefinitionSpec, *v1alpha1.ResourceDefinitionSpec]
 
-type ResourceDefinitionSpecRD struct{}
+type resourceDefinitionExtension struct{}
 
-func (ResourceDefinitionSpecRD) ResourceDefinition(resource.Metadata, resourceDefinition) meta.ResourceDefinitionSpec {
+func (resourceDefinitionExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		DisplayType: "test definition",
 	}
 }
 
 func TestYAMLResourceEquality(t *testing.T) {
-	original := typed.NewResource[resourceDefinition, ResourceDefinitionSpecRD](
+	original := typed.NewResource[resourceDefinition, resourceDefinitionExtension](
 		resource.NewMetadata("default", "testResourceYAML", "aaa", resource.VersionUndefined),
 		protobuf.NewResourceSpec(&v1alpha1.ResourceDefinitionSpec{
 			Aliases: []string{"test", "test2"},
@@ -156,7 +156,7 @@ func TestYAMLResourceEquality(t *testing.T) {
 
 	out := must(yaml.Marshal(original.Spec()))(t)
 
-	result := typed.NewResource[resourceDefinition, ResourceDefinitionSpecRD](
+	result := typed.NewResource[resourceDefinition, resourceDefinitionExtension](
 		resource.NewMetadata("default", "testResourceYAML", "bbb", resource.VersionUndefined),
 		protobuf.NewResourceSpec(&v1alpha1.ResourceDefinitionSpec{}),
 	)
@@ -175,7 +175,7 @@ func TestYAMLResourceEquality(t *testing.T) {
 
 func ExampleResource_testInline() {
 	// This is a test to ensure that our custom 'inline' does work.
-	res := typed.NewResource[resourceDefinition, ResourceDefinitionSpecRD](
+	res := typed.NewResource[resourceDefinition, resourceDefinitionExtension](
 		resource.NewMetadata("default", "testResourceYAML", "aaa", resource.VersionUndefined),
 		protobuf.NewResourceSpec(&v1alpha1.ResourceDefinitionSpec{
 			Aliases: []string{"test", "test2"},

--- a/pkg/resource/protobuf/yaml_test.go
+++ b/pkg/resource/protobuf/yaml_test.go
@@ -33,22 +33,22 @@ const TestType = resource.Type("Test.test.cosi.dev")
 
 type (
 	// TestResource is a test resource.
-	TestResource = typed.Resource[TestSpec, TestRD]
+	TestResource = typed.Resource[TestSpec, TestExtension]
 )
 
 // NewTestResource initializes TestResource resource.
 func NewTestResource(id resource.ID, spec TestSpec) *TestResource {
-	return typed.NewResource[TestSpec, TestRD](
+	return typed.NewResource[TestSpec, TestExtension](
 		resource.NewMetadata(TestNamespaceName, TestType, id, resource.VersionUndefined),
 		spec,
 	)
 }
 
-// TestRD provides auxiliary methods for A.
-type TestRD struct{}
+// TestExtension provides auxiliary methods for A.
+type TestExtension struct{}
 
 // ResourceDefinition implements core.ResourceDefinitionProvider interface.
-func (TestRD) ResourceDefinition(_ resource.Metadata, _ TestSpec) meta.ResourceDefinitionSpec {
+func (TestExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             TestType,
 		DefaultNamespace: TestNamespaceName,

--- a/pkg/resource/typed/typed_resource.go
+++ b/pkg/resource/typed/typed_resource.go
@@ -7,6 +7,7 @@ package typed
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta/spec"
@@ -18,53 +19,103 @@ type DeepCopyable[T any] interface {
 	DeepCopy() T
 }
 
-// ResourceDefinition is a phantom type which acts as info supplier for Resource String and ResourceDefinition
-// methods. It intantianed only during String and ResourceDefinition calls, so it should never contain any data which
-// survives those calls. Any empty struct{} will do.
-type ResourceDefinition[T any] interface {
-	ResourceDefinition(md resource.Metadata, spec T) spec.ResourceDefinitionSpec
+// Extension is a phantom type which acts as info supplier for ResourceDefinition
+// methods. It intantianed only during ResourceDefinition calls, so it should never contain any data which
+// survives those calls. It can be used to provide additional method Make(*resource.Metadata, *T) any, which is used for
+// custom interfaces. Look at LookupExtension and Maker for more details.
+type Extension[T any] interface {
+	ResourceDefinition() spec.ResourceDefinitionSpec
 }
 
 // Resource provides a generic base implementation for resource.Resource.
-type Resource[T DeepCopyable[T], RD ResourceDefinition[T]] struct {
+type Resource[T DeepCopyable[T], E Extension[T]] struct {
 	spec T
 	md   resource.Metadata
 }
 
 // Metadata implements Resource.
-func (t *Resource[T, RD]) Metadata() *resource.Metadata {
+func (t *Resource[T, E]) Metadata() *resource.Metadata {
 	return &t.md
 }
 
 // Spec implements resource.Resource.
-func (t *Resource[T, RD]) Spec() interface{} {
+func (t *Resource[T, E]) Spec() interface{} {
 	return &t.spec
 }
 
 // TypedSpec returns a pointer to spec field.
-func (t *Resource[T, RD]) TypedSpec() *T {
+func (t *Resource[T, E]) TypedSpec() *T {
 	return &t.spec
 }
 
 // DeepCopy returns a deep copy of Resource.
-func (t *Resource[T, RD]) DeepCopy() resource.Resource { //nolint:ireturn
-	return &Resource[T, RD]{t.spec.DeepCopy(), t.md}
+func (t *Resource[T, E]) DeepCopy() resource.Resource { //nolint:ireturn
+	return &Resource[T, E]{t.spec.DeepCopy(), t.md}
 }
 
 // ResourceDefinition implements spec.ResourceDefinitionProvider interface.
-func (t *Resource[T, RD]) ResourceDefinition() spec.ResourceDefinitionSpec {
-	var (
-		zero  RD
-		zeroT T
-	)
+func (t *Resource[T, E]) ResourceDefinition() spec.ResourceDefinitionSpec {
+	var zero E
 
-	return zero.ResourceDefinition(resource.Metadata{}, zeroT)
+	return zero.ResourceDefinition()
+}
+
+// Maker is an interface which can be implemented by resource extension to provide custom interfaces.
+type Maker[T any] interface {
+	Make(*resource.Metadata, *T) any
+}
+
+func (t *Resource[T, E]) makeRD() (any, bool) {
+	var e E
+
+	maker, ok := any(e).(Maker[T])
+	if ok {
+		return maker.Make(t.Metadata(), t.TypedSpec()), true
+	}
+
+	return nil, false
+}
+
+// LookupExtension looks up for the [Maker] interface on the resource extension.
+// It will call Make method on it, if it has one, passing [resource.Metadata] and typed spec as arguments,
+// before returning the result of Make call and attempting to cast it to the provided type parameter I.
+// I should be an interface with a single method
+//
+// The common usage is to define `Make(...) any` on extension type, and return custom type which implements I.
+func LookupExtension[I any](res resource.Resource) (I, bool) {
+	var zero I
+
+	typ := reflect.TypeOf((*I)(nil)).Elem()
+	if typ.Kind() != reflect.Interface {
+		panic("can only be used with interface types")
+	}
+
+	if typ.NumMethod() != 1 {
+		panic("can only be used with interfaces with a single method")
+	}
+
+	maker, ok := res.(interface{ makeRD() (any, bool) })
+	if !ok {
+		return zero, false
+	}
+
+	v, ok := maker.makeRD()
+	if !ok {
+		return zero, false
+	}
+
+	iface, ok := v.(I)
+	if !ok {
+		return zero, false
+	}
+
+	return iface, true
 }
 
 // UnmarshalProto implements protobuf.Unmarshaler interface in a generic way.
 //
 // UnmarshalProto requires that the spec implements the protobuf.ProtoUnmarshaller interface.
-func (t *Resource[T, RD]) UnmarshalProto(md *resource.Metadata, protoBytes []byte) error {
+func (t *Resource[T, E]) UnmarshalProto(md *resource.Metadata, protoBytes []byte) error {
 	// Go doesn't allow to do type assertion on a generic type T, so use intermediate any value.
 	protoSpec, ok := any(&t.spec).(protobuf.ProtoUnmarshaler)
 	if !ok {
@@ -81,8 +132,8 @@ func (t *Resource[T, RD]) UnmarshalProto(md *resource.Metadata, protoBytes []byt
 }
 
 // NewResource initializes and returns a new instance of Resource with typed spec field.
-func NewResource[T DeepCopyable[T], RD ResourceDefinition[T]](md resource.Metadata, spec T) *Resource[T, RD] {
-	result := Resource[T, RD]{md: md, spec: spec}
+func NewResource[T DeepCopyable[T], E Extension[T]](md resource.Metadata, spec T) *Resource[T, E] {
+	result := Resource[T, E]{md: md, spec: spec}
 
 	return &result
 }

--- a/pkg/state/impl/store/bolt/example_test.go
+++ b/pkg/state/impl/store/bolt/example_test.go
@@ -28,9 +28,9 @@ import (
 
 type ExampleSpec = protobuf.ResourceSpec[v1alpha1.Metadata, *v1alpha1.Metadata]
 
-type ExampleRD struct{}
+type ExampleExtension struct{}
 
-func (ExampleRD) ResourceDefinition(_ resource.Metadata, _ ExampleSpec) meta.ResourceDefinitionSpec {
+func (ExampleExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type: "testResource",
 	}
@@ -92,7 +92,7 @@ func Example() {
 		},
 	))
 
-	r1 := typed.NewResource[ExampleSpec, ExampleRD](
+	r1 := typed.NewResource[ExampleSpec, ExampleExtension](
 		resource.NewMetadata(
 			"persistent",
 			"testResource",


### PR DESCRIPTION
This commit allows us to define and use custom methods on renamed `ResourceDefinition` -> `Extension` type.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>