### PR TITLE
feat: implement compressed resource marshaling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/hashicorp/go-memdb v1.3.4
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/klauspost/compress v1.16.3
 	github.com/siderolabs/gen v0.4.3
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/siderolabs/go-retry v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
+github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/pkg/state/impl/store/compression/compression.go
+++ b/pkg/state/impl/store/compression/compression.go
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package compression provides compression support for [store.Marshaler].
+package compression
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state/impl/store"
+)
+
+// Marshaler compresses and decompresses data from the underlying marshaler.
+//
+// Marshaler also handles case when the underlying data is not compressed.
+//
+// The trick used is that `0x00` can't start a valid protobuf message, so we use
+// `0x00` as a marker for compressed data.
+type Marshaler struct {
+	underlying store.Marshaler
+	compressor Compressor
+	minSize    int
+}
+
+// Compressor defines interface for compression and decompression.
+type Compressor interface {
+	Compress(prefix, data []byte) ([]byte, error)
+	Decompress(data []byte) ([]byte, error)
+	ID() byte
+}
+
+// NewMarshaler creates new Marshaler.
+func NewMarshaler(m store.Marshaler, c Compressor, minSize int) *Marshaler {
+	return &Marshaler{underlying: m, compressor: c, minSize: minSize}
+}
+
+// MarshalResource implements Marshaler interface.
+func (m *Marshaler) MarshalResource(r resource.Resource) ([]byte, error) {
+	encoded, err := m.underlying.MarshalResource(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource: %w", err)
+	}
+
+	if len(encoded) < m.minSize {
+		return encoded, nil
+	}
+
+	compressed, err := m.compressor.Compress([]byte{0x0, m.compressor.ID()}, encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compress: %w", err)
+	}
+
+	return compressed, nil
+}
+
+// UnmarshalResource implements Marshaler interface.
+func (m *Marshaler) UnmarshalResource(b []byte) (resource.Resource, error) { //nolint:ireturn
+	if len(b) > 1 && b[0] == 0x0 {
+		id := b[1]
+
+		if id != m.compressor.ID() {
+			return nil, fmt.Errorf("unknown compression ID: %d", id)
+		}
+
+		var err error
+
+		// Data is compressed, decompress it.
+		b, err = m.compressor.Decompress(b[2:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decompress: %w", err)
+		}
+	}
+
+	return m.underlying.UnmarshalResource(b)
+}

--- a/pkg/state/impl/store/compression/compression_test.go
+++ b/pkg/state/impl/store/compression/compression_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package store_test
+package compression_test
 
 import (
 	"strings"
@@ -15,32 +15,49 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/state/conformance"
 	"github.com/cosi-project/runtime/pkg/state/impl/store"
+	"github.com/cosi-project/runtime/pkg/state/impl/store/compression"
 )
 
-func TestProtobufMarshaler(t *testing.T) {
-	path := conformance.NewPathResource("default", "var/run")
-	path.Metadata().Labels().Set("app", "foo")
-	path.Metadata().Annotations().Set("ttl", "1h")
-	path.Metadata().Finalizers().Add("controller1")
-
-	marshaler := store.ProtobufMarshaler{}
-
-	data, err := marshaler.MarshalResource(path)
-	require.NoError(t, err)
-
-	unmarshaled, err := marshaler.UnmarshalResource(data)
-	require.NoError(t, err)
-
-	assert.Equal(t, resource.String(path), resource.String(unmarshaled))
-}
-
-func BenchmarkProto(b *testing.B) {
+func TestCompressedProtobufMarshaler(t *testing.T) {
 	path := conformance.NewPathResource("default", strings.Repeat("var/run", 100))
 	path.Metadata().Labels().Set("app", "foo")
 	path.Metadata().Annotations().Set("ttl", "1h")
 	path.Metadata().Finalizers().Add("controller1")
 
-	marshaler := store.ProtobufMarshaler{}
+	protoMarshaler := store.ProtobufMarshaler{}
+	marshaler := compression.NewMarshaler(protoMarshaler, compression.ZStd(), 256)
+
+	compressedData, err := marshaler.MarshalResource(path)
+	require.NoError(t, err)
+
+	rawData, err := protoMarshaler.MarshalResource(path)
+	require.NoError(t, err)
+
+	assert.Less(t, len(compressedData), len(rawData))
+	t.Logf("compressed data size: %d, raw data size: %d", len(compressedData), len(rawData))
+
+	assert.Equal(t, []byte("\000z"), compressedData[:2])
+
+	unmarshaled, err := marshaler.UnmarshalResource(compressedData)
+	require.NoError(t, err)
+
+	assert.True(t, resource.Equal(path, unmarshaled))
+
+	// test that uncompressed data is handled correctly
+	unmarshaled2, err := marshaler.UnmarshalResource(rawData)
+	require.NoError(t, err)
+
+	assert.Equal(t, unmarshaled, unmarshaled2)
+}
+
+func BenchmarkZstd(b *testing.B) {
+	path := conformance.NewPathResource("default", strings.Repeat("var/run", 100))
+	path.Metadata().Labels().Set("app", "foo")
+	path.Metadata().Annotations().Set("ttl", "1h")
+	path.Metadata().Finalizers().Add("controller1")
+
+	protoMarshaler := store.ProtobufMarshaler{}
+	marshaler := compression.NewMarshaler(protoMarshaler, compression.ZStd(), 256)
 
 	for i := 0; i < b.N; i++ {
 		_, err := marshaler.MarshalResource(path)

--- a/pkg/state/impl/store/compression/zstd.go
+++ b/pkg/state/impl/store/compression/zstd.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package compression
+
+import "github.com/klauspost/compress/zstd"
+
+// ZStd returns zstd compressor.
+func ZStd() Compressor {
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+
+	decoder, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+
+	return &zstdCompressor{
+		encoder: encoder,
+		decoder: decoder,
+	}
+}
+
+var _ Compressor = (*zstdCompressor)(nil)
+
+type zstdCompressor struct {
+	encoder *zstd.Encoder
+	decoder *zstd.Decoder
+}
+
+func (z *zstdCompressor) Compress(prefix, data []byte) ([]byte, error) {
+	return z.encoder.EncodeAll(data, prefix), nil
+}
+
+func (z *zstdCompressor) Decompress(data []byte) ([]byte, error) {
+	return z.decoder.DecodeAll(data, nil)
+}
+
+func (z *zstdCompressor) ID() byte {
+	return 'z'
+}


### PR DESCRIPTION
It is backwards compatible (i.e. it can read uncompressed resources), and it has a minimum size to be enabled.

This should help a lot with resources which have compressible data.