### PR TITLE
chore: unify all ResourceWithRD as an alias to meta.ResourceWithRD

### DIFF
--- a/pkg/controller/generic/generic.go
+++ b/pkg/controller/generic/generic.go
@@ -6,17 +6,11 @@
 package generic
 
 import (
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
-// ResourceWithRD is a resource providing resource definition.
-//
-// ResourceWithRD allows to pull resource namespace and type from the RD.
-type ResourceWithRD interface {
-	resource.Resource
-	meta.ResourceDefinitionProvider
-}
+// ResourceWithRD is an alias for meta.ResourceWithRD.
+type ResourceWithRD = meta.ResourceWithRD
 
 // NamedController is provides Name() method.
 type NamedController struct {

--- a/pkg/resource/meta/resource_definition.go
+++ b/pkg/resource/meta/resource_definition.go
@@ -62,6 +62,14 @@ type ResourceDefinitionProvider interface {
 	ResourceDefinition() ResourceDefinitionSpec
 }
 
+// ResourceWithRD is a resource providing resource definition.
+//
+// ResourceWithRD allows to pull resource namespace and type from the RD.
+type ResourceWithRD interface {
+	ResourceDefinitionProvider
+	resource.Resource
+}
+
 func init() {
 	if err := protobuf.RegisterResource(ResourceDefinitionType, &ResourceDefinition{}); err != nil {
 		panic(err)

--- a/pkg/resource/rtestutils/rtestutils.go
+++ b/pkg/resource/rtestutils/rtestutils.go
@@ -6,12 +6,8 @@
 package rtestutils
 
 import (
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
-// ResourceWithRD is a resource providing resource definition.
-type ResourceWithRD interface {
-	resource.Resource
-	meta.ResourceDefinitionProvider
-}
+// ResourceWithRD is an alias for meta.ResourceWithRD.
+type ResourceWithRD = meta.ResourceWithRD

--- a/pkg/state/registry/resource.go
+++ b/pkg/state/registry/resource.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/state"
 )
@@ -27,7 +26,7 @@ func NewResourceRegistry(state state.State) *ResourceRegistry {
 
 // RegisterDefault registers default resource definitions.
 func (registry *ResourceRegistry) RegisterDefault(ctx context.Context) error {
-	for _, r := range []resource.Resource{&meta.ResourceDefinition{}, &meta.Namespace{}} {
+	for _, r := range []meta.ResourceWithRD{&meta.ResourceDefinition{}, &meta.Namespace{}} {
 		if err := registry.Register(ctx, r); err != nil {
 			return err
 		}
@@ -37,15 +36,8 @@ func (registry *ResourceRegistry) RegisterDefault(ctx context.Context) error {
 }
 
 // Register a namespace.
-func (registry *ResourceRegistry) Register(ctx context.Context, r resource.Resource) error {
-	definitionProvider, ok := r.(meta.ResourceDefinitionProvider)
-	if !ok {
-		return fmt.Errorf("value %v doesn't implement core.ResourceDefinitionProvider", r)
-	}
-
-	definition := definitionProvider.ResourceDefinition()
-
-	r, err := meta.NewResourceDefinition(definition)
+func (registry *ResourceRegistry) Register(ctx context.Context, r meta.ResourceWithRD) error {
+	r, err := meta.NewResourceDefinition(r.ResourceDefinition())
 	if err != nil {
 		return fmt.Errorf("error registering resource %s: %w", r, err)
 	}


### PR DESCRIPTION
Also, `ResourceRegistry.Register` now accepts `meta.ResourceWithRD` instead of plain `resource.Resource`. This removes the need for type assertion.