### PR TITLE
chore: add `ReconcileEventCh` support type

### DIFF
--- a/pkg/controller/conformance/controllers.go
+++ b/pkg/controller/conformance/controllers.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/siderolabs/gen/channel"
 	"go.uber.org/zap"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -62,8 +61,7 @@ func (ctrl *IntToStrController) Run(ctx context.Context, r controller.Runtime, _
 	sourceMd := resource.NewMetadata(ctrl.SourceNamespace, IntResourceType, "", resource.VersionUndefined)
 
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 
@@ -169,8 +167,7 @@ func (ctrl *StrToSentenceController) Run(ctx context.Context, r controller.Runti
 	sourceMd := resource.NewMetadata(ctrl.SourceNamespace, StrResourceType, "", resource.VersionUndefined)
 
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 
@@ -270,8 +267,7 @@ func (ctrl *SumController) Run(ctx context.Context, r controller.Runtime, _ *zap
 	sourceMd := resource.NewMetadata(ctrl.SourceNamespace, IntResourceType, "", resource.VersionUndefined)
 
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 
@@ -331,8 +327,7 @@ func (ctrl *FailingController) Outputs() []controller.Output {
 
 // Run implements controller.Controller interface.
 func (ctrl *FailingController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
-	_, ok := channel.RecvWithContext(ctx, r.EventCh())
-	if !ok {
+	if !r.EventCh().Recv(ctx) {
 		return nil
 	}
 
@@ -390,8 +385,7 @@ func (ctrl *IntDoublerController) Run(ctx context.Context, r controller.Runtime,
 	sourceMd := resource.NewMetadata(ctrl.SourceNamespace, IntResourceType, "", resource.VersionUndefined)
 
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 

--- a/pkg/controller/generic/cleanup/cleanup.go
+++ b/pkg/controller/generic/cleanup/cleanup.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
@@ -86,8 +85,7 @@ func (ctrl *Controller[I]) Outputs() []controller.Output {
 // Run implements controller.Controller interface.
 func (ctrl *Controller[I]) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 

--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
@@ -195,8 +194,7 @@ func (ctrl *Controller[Input, Output]) Run(ctx context.Context, r controller.Run
 	)
 
 	for {
-		_, ok := channel.RecvWithContext(ctx, r.EventCh())
-		if !ok {
+		if !r.EventCh().Recv(ctx) {
 			return nil
 		}
 

--- a/pkg/controller/protobuf/client/client.go
+++ b/pkg/controller/protobuf/client/client.go
@@ -315,7 +315,7 @@ func (ctrlAdapter *controllerAdapter) establishEventChannel() {
 	}
 }
 
-func (ctrlAdapter *controllerAdapter) EventCh() <-chan controller.ReconcileEvent {
+func (ctrlAdapter *controllerAdapter) EventCh() controller.ReconcileEventCh {
 	return ctrlAdapter.eventCh
 }
 

--- a/pkg/controller/protobuf/server/server.go
+++ b/pkg/controller/protobuf/server/server.go
@@ -206,8 +206,7 @@ func (runtime *Runtime) ReconcileEvents(req *v1alpha1.ReconcileEventsRequest, sr
 	}
 
 	for {
-		_, ok := channel.RecvWithContext(srv.Context(), bridge.adapter.EventCh())
-		if !ok {
+		if !bridge.adapter.EventCh().Recv(srv.Context()) {
 			return srv.Context().Err()
 		}
 

--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -14,9 +14,23 @@ import (
 // ReconcileEvent is a signal for controller to reconcile its resources.
 type ReconcileEvent struct{}
 
+// ReconcileEventCh is a channel for receiving reconcile events.
+type ReconcileEventCh <-chan ReconcileEvent
+
+// Recv is a helper method for waiting the reconcile event. Because we promise that the
+// channel is never closed, we only return false if the context was canceled.
+func (ch ReconcileEventCh) Recv(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-ch:
+		return true
+	}
+}
+
 // Runtime interface as presented to the controller.
 type Runtime interface {
-	EventCh() <-chan ReconcileEvent
+	EventCh() ReconcileEventCh
 	QueueReconcile()
 	ResetRestartBackoff()
 

--- a/pkg/controller/runtime/adapter.go
+++ b/pkg/controller/runtime/adapter.go
@@ -78,7 +78,7 @@ func reduceMetadata(md *resource.Metadata) reducedMetadata {
 type watchFilter func(*reducedMetadata) bool
 
 // EventCh implements controller.Runtime interface.
-func (adapter *adapter) EventCh() <-chan controller.ReconcileEvent {
+func (adapter *adapter) EventCh() controller.ReconcileEventCh {
 	return adapter.ch
 }
 


### PR DESCRIPTION
By defining custom type on top of `<-chan ReconcileEvent` and defining helper method, we can write code like this:

```go
if !r.EventCh().Recv(ctx) {
	return nil
}
```

Which is more straightforward than

```go
select {
case <-ctx.Done():
	return false
case <-r.EventCh():
	// our logic here
}
```

And definitely easier than:

```go
if _, ok := channel.RecvWithContext(ctx, r.EventCh()); !ok && ctx.Err() != nil {
	return nil //nolint:nilerr
}
```

This is a breaking change, but in reality it should not require any updates to Talos code.