### PR TITLE
fix: properly invert numeric < and <= operators

### DIFF
--- a/pkg/resource/labels_test.go
+++ b/pkg/resource/labels_test.go
@@ -84,6 +84,22 @@ func TestLabels(t *testing.T) {
 		Op:     resource.LabelOpExists,
 		Invert: true,
 	}))
+
+	termTests.Set("num", "100")
+
+	assert.False(t, termTests.Matches(resource.LabelTerm{
+		Key:    "num",
+		Op:     resource.LabelOpLTNumeric,
+		Value:  []string{"NaN"},
+		Invert: true,
+	}))
+
+	assert.False(t, termTests.Matches(resource.LabelTerm{
+		Key:    "num",
+		Op:     resource.LabelOpLTENumeric,
+		Value:  []string{"NaN"},
+		Invert: true,
+	}))
 }
 
 func TestLabelsDo(t *testing.T) {


### PR DESCRIPTION
Introduce `nil` value which is never true, even if `invert` is set on the term.
`nil` is returned when parsing string to number fails on the label value or on the term value.