### PR TITLE
fix: properly handle invert for comparison, when key not found

### DIFF
--- a/pkg/resource/label_query.go
+++ b/pkg/resource/label_query.go
@@ -29,6 +29,20 @@ const (
 	LabelOpLTENumeric
 )
 
+func (l LabelOp) isComparison() bool {
+	//nolint:exhaustive
+	switch l {
+	case LabelOpLT:
+	case LabelOpLTE:
+	case LabelOpLTNumeric:
+	case LabelOpLTENumeric:
+	default:
+		return false
+	}
+
+	return true
+}
+
 // LabelTerm describes a filter on metadata labels.
 type LabelTerm struct {
 	Key    string

--- a/pkg/resource/labels.go
+++ b/pkg/resource/labels.go
@@ -54,6 +54,10 @@ func (labels Labels) matches(term LabelTerm) *bool {
 	value, ok := labels.Get(term.Key)
 
 	if !ok {
+		if term.Op.isComparison() {
+			return nil
+		}
+
 		return pointer.To(false)
 	}
 

--- a/pkg/resource/labels_test.go
+++ b/pkg/resource/labels_test.go
@@ -100,6 +100,13 @@ func TestLabels(t *testing.T) {
 		Value:  []string{"NaN"},
 		Invert: true,
 	}))
+
+	assert.False(t, termTests.Matches(resource.LabelTerm{
+		Key:    "nm",
+		Op:     resource.LabelOpLTENumeric,
+		Value:  []string{"NaN"},
+		Invert: true,
+	}))
 }
 
 func TestLabelsDo(t *testing.T) {


### PR DESCRIPTION
Should return `nil` if the key doesn't exist in the labels.