### PR TITLE
feat: add extra channel support to transform controller

### DIFF
--- a/pkg/controller/generic/transform/controller.go
+++ b/pkg/controller/generic/transform/controller.go
@@ -198,6 +198,7 @@ func (ctrl *Controller[Input, Output]) Run(ctx context.Context, r controller.Run
 		case <-ctx.Done():
 			return nil
 		case <-r.EventCh():
+		case <-ctrl.options.extraEventCh:
 		}
 
 		// controller runs in two phases:

--- a/pkg/controller/generic/transform/options.go
+++ b/pkg/controller/generic/transform/options.go
@@ -11,6 +11,7 @@ import (
 
 // ControllerOptions configures TransformController.
 type ControllerOptions struct {
+	extraEventCh            <-chan struct{}
 	inputListOptions        []state.ListOption
 	extraInputs             []controller.Input
 	extraOutputs            []controller.Output
@@ -21,9 +22,9 @@ type ControllerOptions struct {
 // ControllerOption is an option for TransformController.
 type ControllerOption func(*ControllerOptions)
 
-// WithInputListOptions adds an filter on input resource list.
+// WithInputListOptions adds a filter on input resource list.
 //
-// E.g. query only resources with specific labels.
+// E.g., query only resources with specific labels.
 func WithInputListOptions(opts ...state.ListOption) ControllerOption {
 	return func(o *ControllerOptions) {
 		o.inputListOptions = append(o.inputListOptions, opts...)
@@ -68,5 +69,15 @@ func WithIgnoreTearingDownInputs() ControllerOption {
 		}
 
 		o.ignoreTearingDownInputs = true
+	}
+}
+
+// WithExtraEventChannel adds an extra event channel to the controller.
+//
+// When this channel receives data, the controller will run the transform function.
+// This is useful to wake up the controller from a goroutine.
+func WithExtraEventChannel(extraEventCh <-chan struct{}) ControllerOption {
+	return func(o *ControllerOptions) {
+		o.extraEventCh = extraEventCh
 	}
 }

--- a/pkg/controller/generic/transform/resource_test.go
+++ b/pkg/controller/generic/transform/resource_test.go
@@ -79,7 +79,8 @@ func (BE) ResourceDefinition() meta.ResourceDefinitionSpec {
 
 // BSpec provides B definition.
 type BSpec struct {
-	Out string
+	Out            string
+	TransformCount int
 }
 
 // DeepCopy generates a deep copy of BSpec.


### PR DESCRIPTION
Add an option to specify an extra channel to the transform controller. Controller will wake up upon receiving data from the channel and run transform.