### PR TITLE
test: ignore not found when destroying in rtestutils

### DIFF
--- a/pkg/resource/rtestutils/destroy.go
+++ b/pkg/resource/rtestutils/destroy.go
@@ -68,7 +68,7 @@ func Destroy[R ResourceWithRD](ctx context.Context, t *testing.T, st state.State
 
 			if r.Metadata().Phase() == resource.PhaseTearingDown && r.Metadata().Finalizers().Empty() {
 				// time to destroy
-				require.NoError(t, st.Destroy(ctx, r.Metadata()))
+				require.NoError(t, ignoreNotFound(st.Destroy(ctx, r.Metadata())))
 
 				t.Logf("cleaned up %s ID %q", rds.Type, r.Metadata().ID())
 			}
@@ -95,4 +95,12 @@ func teardown(ctx context.Context, st state.State, ids []string, rds meta.Resour
 	}
 
 	return nil
+}
+
+func ignoreNotFound(err error) error {
+	if state.IsNotFoundError(err) {
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
If some other entity cleans up torn down resources, `rtestutils.Destroy` might fail trying to destroy already destroyed resource.

Fix that by ignoring 'not found' errors on destroy.