### PR TITLE
refactor: optimize the metadata.Equal for small number of finalizers

### DIFF
--- a/pkg/resource/metadata.go
+++ b/pkg/resource/metadata.go
@@ -6,7 +6,7 @@ package resource
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/siderolabs/gen/xslices"
@@ -172,19 +172,23 @@ func (md Metadata) Equal(other Metadata) bool {
 		return true
 	}
 
-	fins := append(Finalizers(nil), md.fins...)
-	otherFins := append(Finalizers(nil), other.fins...)
+	switch len(md.fins) {
+	case 0:
+		return true
+	case 1:
+		return md.fins[0] == other.fins[0]
+	case 2:
+		return md.fins[0] == other.fins[0] && md.fins[1] == other.fins[1] ||
+			md.fins[0] == other.fins[1] && md.fins[1] == other.fins[0]
+	default:
+		fins := slices.Clone(md.fins)
+		otherFins := slices.Clone(other.fins)
 
-	sort.Strings(fins)
-	sort.Strings(otherFins)
+		slices.Sort(fins)
+		slices.Sort(otherFins)
 
-	for i := range fins {
-		if fins[i] != otherFins[i] {
-			return false
-		}
+		return slices.Equal(fins, otherFins)
 	}
-
-	return true
 }
 
 // MarshalYAML implements yaml.Marshaller interface.

--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -6,6 +6,7 @@ package resource_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -253,4 +254,26 @@ func TestNewMedataFromProto(t *testing.T) {
 	other.Labels().Set("app", "foo")
 
 	assert.True(t, md.Equal(other))
+}
+
+func BenchmarkMetadataEqual(b *testing.B) {
+	for _, l := range []int{0, 1, 2, 3} {
+		b.Run(strconv.Itoa(l), func(b *testing.B) {
+			md := resource.NewMetadata("default", "type", "aaa", resource.VersionUndefined)
+			other := resource.NewMetadata("default", "type", "aaa", resource.VersionUndefined)
+
+			for i := 0; i < l; i++ {
+				md.Finalizers().Add(fmt.Sprintf("finalizer-%d", i))
+				other.Finalizers().Add(fmt.Sprintf("finalizer-%d", l-i-1))
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if !md.Equal(other) {
+					b.FailNow()
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
It might be pretty common to have 1-2 finalizers, so we can do a special case for it.

```
name                old time/op    new time/op    delta
MetadataEqual/0-32    12.1ns ± 2%    11.8ns ± 2%      ~     (p=0.057 n=4+4)
MetadataEqual/1-32     206ns ± 8%      14ns ± 0%   -93.11%  (p=0.029 n=4+4)
MetadataEqual/2-32     268ns ± 7%      21ns ± 2%   -92.13%  (p=0.029 n=4+4)
MetadataEqual/3-32     328ns ± 4%     227ns ± 4%   -30.86%  (p=0.029 n=4+4)

name                old alloc/op   new alloc/op   delta
MetadataEqual/0-32     0.00B          0.00B           ~     (all equal)
MetadataEqual/1-32     80.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
MetadataEqual/2-32      112B ± 0%        0B       -100.00%  (p=0.029 n=4+4)
MetadataEqual/3-32      144B ± 0%       96B ± 0%   -33.33%  (p=0.029 n=4+4)

name                old allocs/op  new allocs/op  delta
MetadataEqual/0-32      0.00           0.00           ~     (all equal)
MetadataEqual/1-32      4.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
MetadataEqual/2-32      4.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
MetadataEqual/3-32      4.00 ± 0%      2.00 ± 0%   -50.00%  (p=0.029 n=4+4)
```

Fixes #306