### PR TITLE
feat: add `ModifyWithResult` to `controller.Writer` interface

### DIFF
--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -115,6 +115,7 @@ type Writer interface {
 	Create(context.Context, resource.Resource) error
 	Update(context.Context, resource.Resource) error
 	Modify(context.Context, resource.Resource, func(resource.Resource) error) error
+	ModifyWithResult(context.Context, resource.Resource, func(resource.Resource) error) (resource.Resource, error)
 	Teardown(context.Context, resource.Pointer, ...Option) (bool, error)
 	Destroy(context.Context, resource.Pointer, ...Option) error
 

--- a/pkg/safe/reader.go
+++ b/pkg/safe/reader.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package safe provides a safe wrappers around the cosi runtime.
 package safe
 
 import (

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package safe provides a safe wrappers around the cosi runtime.
+package safe
+
+import "github.com/cosi-project/runtime/pkg/resource"
+
+func typeAssertOrZero[T resource.Resource](got resource.Resource, err error) (T, error) { //nolint:ireturn
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	result, ok := got.(T)
+	if !ok {
+		var zero T
+
+		return zero, typeMismatchErr(result, got)
+	}
+
+	return result, nil
+}

--- a/pkg/safe/state.go
+++ b/pkg/safe/state.go
@@ -20,23 +20,6 @@ func typeMismatchErr(expected, got any) error {
 	return fmt.Errorf("type mismatch: expected %T, got %T", expected, got)
 }
 
-func typeAssertOrZero[T resource.Resource](got resource.Resource, err error) (T, error) { //nolint:ireturn
-	if err != nil {
-		var zero T
-
-		return zero, err
-	}
-
-	result, ok := got.(T)
-	if !ok {
-		var zero T
-
-		return zero, typeMismatchErr(result, got)
-	}
-
-	return result, nil
-}
-
 // StateGet is a type safe wrapper around state.Get.
 func StateGet[T resource.Resource](ctx context.Context, st state.CoreState, ptr resource.Pointer, options ...state.GetOption) (T, error) { //nolint:ireturn
 	got, err := st.Get(ctx, ptr, options...)

--- a/pkg/safe/writer.go
+++ b/pkg/safe/writer.go
@@ -23,3 +23,17 @@ func WriterModify[T resource.Resource](ctx context.Context, writer controller.Wr
 		return fn(arg)
 	})
 }
+
+// WriterModifyWithResult is a type safe wrapper around writer.ModifyWithResult.
+func WriterModifyWithResult[T resource.Resource](ctx context.Context, writer controller.Writer, r T, fn func(T) error) (T, error) {
+	got, err := writer.ModifyWithResult(ctx, r, func(r resource.Resource) error {
+		arg, ok := r.(T)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected %T, got %T", arg, r)
+		}
+
+		return fn(arg)
+	})
+
+	return typeAssertOrZero[T](got, err)
+}


### PR DESCRIPTION
Add a new method, `ModifyWithResult` to the `controller.Writer` interface. This is the equivalent of `state.UpdateWithConflicts`, which returns the created/updated resource after the operation.

Also add its safe variant, `safe.WriterModifyWithResult`.