### PR TITLE
feat: expose controller metrics using `expvar`

### DIFF
--- a/pkg/controller/runtime/metrics/metrics.go
+++ b/pkg/controller/runtime/metrics/metrics.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package metrics expose various controller runtime metrics using expvar.
+package metrics
+
+import (
+	"expvar"
+)
+
+var (
+	// ControllerCrashes counts the number of crashes per controller.
+	ControllerCrashes = expvar.NewMap("controller_crashes")
+
+	// ControllerWakeups counts the number of wakeups per controller.
+	ControllerWakeups = expvar.NewMap("controller_wakeups")
+
+	// ControllerReads counts the number of reads per controller.
+	//
+	// Each call to controller.Reader is counted as a single read.
+	ControllerReads = expvar.NewMap("controller_reads")
+
+	// ControllerWrites counts the number of writes per controller.
+	//
+	// Each call to controller.Writer is counted as a single write.
+	ControllerWrites = expvar.NewMap("controller_writes")
+)


### PR DESCRIPTION
Expose:
- controller crashes
- controller wakeups
- controller reads
- controller writes

using the expvar package.

Closes cosi-project/runtime#344.

Example output from the `/debug/vars` endpoint:
```json
{
"cmdline": ["/Users/utku/Library/Caches/JetBrains/GoLand2023.2/tmp/GoLand/___run_inmem","--grpc-address=127.0.0.1:8181","--http-address=127.0.0.1:8182"],
"controller_crashes": {"IntToStrController": 6},
"controller_reads": {"IntToStrController": 11},
"controller_wakeups": {"IntToStrController": 11},
"controller_writes": {"IntToStrController": 36},
"memstats": {"Alloc":1147736,"TotalAlloc":1147736,"Sys":8031248,"Lookups":0,"Mallocs":6876,"Frees":335,"HeapAlloc":1147736,"HeapSys":3604480,"HeapIdle":1425408,"HeapInuse":2179072,"HeapReleased":1425408,"HeapObjects":6541,"StackInuse":589824,"StackSys":589824,"MSpanInuse":46536,"MSpanSys":48888,"MCacheInuse":12000,"MCacheSys":15600,"BuckHashSys":5080,"GCSys":3131136,"OtherSys":636240,"NextGC":4194304,"LastGC":0,"PauseTotalNs":0,"PauseNs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"PauseEnd":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"NumGC":0,"NumForcedGC":0,"GCCPUFraction":0,"EnableGC":true,"DebugGC":false,"BySize":[{"Size":0,"Mallocs":0,"Frees":0},{"Size":8,"Mallocs":242,"Frees":0},{"Size":16,"Mallocs":1978,"Frees":0},{"Size":24,"Mallocs":413,"Frees":0},{"Size":32,"Mallocs":531,"Frees":0},{"Size":48,"Mallocs":607,"Frees":0},{"Size":64,"Mallocs":259,"Frees":0},{"Size":80,"Mallocs":130,"Frees":0},{"Size":96,"Mallocs":85,"Frees":0},{"Size":112,"Mallocs":984,"Frees":0},{"Size":128,"Mallocs":148,"Frees":0},{"Size":144,"Mallocs":39,"Frees":0},{"Size":160,"Mallocs":204,"Frees":0},{"Size":176,"Mallocs":153,"Frees":0},{"Size":192,"Mallocs":75,"Frees":0},{"Size":208,"Mallocs":78,"Frees":0},{"Size":224,"Mallocs":22,"Frees":0},{"Size":240,"Mallocs":2,"Frees":0},{"Size":256,"Mallocs":36,"Frees":0},{"Size":288,"Mallocs":38,"Frees":0},{"Size":320,"Mallocs":89,"Frees":0},{"Size":352,"Mallocs":25,"Frees":0},{"Size":384,"Mallocs":3,"Frees":0},{"Size":416,"Mallocs":54,"Frees":0},{"Size":448,"Mallocs":21,"Frees":0},{"Size":480,"Mallocs":4,"Frees":0},{"Size":512,"Mallocs":7,"Frees":0},{"Size":576,"Mallocs":16,"Frees":0},{"Size":640,"Mallocs":68,"Frees":0},{"Size":704,"Mallocs":13,"Frees":0},{"Size":768,"Mallocs":4,"Frees":0},{"Size":896,"Mallocs":10,"Frees":0},{"Size":1024,"Mallocs":11,"Frees":0},{"Size":1152,"Mallocs":22,"Frees":0},{"Size":1280,"Mallocs":53,"Frees":0},{"Size":1408,"Mallocs":8,"Frees":0},{"Size":1536,"Mallocs":1,"Frees":0},{"Size":1792,"Mallocs":14,"Frees":0},{"Size":2048,"Mallocs":6,"Frees":0},{"Size":2304,"Mallocs":9,"Frees":0},{"Size":2688,"Mallocs":17,"Frees":0},{"Size":3072,"Mallocs":1,"Frees":0},{"Size":3200,"Mallocs":1,"Frees":0},{"Size":3456,"Mallocs":0,"Frees":0},{"Size":4096,"Mallocs":16,"Frees":0},{"Size":4864,"Mallocs":5,"Frees":0},{"Size":5376,"Mallocs":10,"Frees":0},{"Size":6144,"Mallocs":8,"Frees":0},{"Size":6528,"Mallocs":1,"Frees":0},{"Size":6784,"Mallocs":0,"Frees":0},{"Size":6912,"Mallocs":0,"Frees":0},{"Size":8192,"Mallocs":4,"Frees":0},{"Size":9472,"Mallocs":14,"Frees":0},{"Size":9728,"Mallocs":0,"Frees":0},{"Size":10240,"Mallocs":0,"Frees":0},{"Size":10880,"Mallocs":0,"Frees":0},{"Size":12288,"Mallocs":1,"Frees":0},{"Size":13568,"Mallocs":0,"Frees":0},{"Size":14336,"Mallocs":0,"Frees":0},{"Size":16384,"Mallocs":0,"Frees":0},{"Size":18432,"Mallocs":1,"Frees":0}]}
}
```