### PR TITLE
feat: support requeue in the transform controller

### DIFF
--- a/pkg/controller/generic/transform/options.go
+++ b/pkg/controller/generic/transform/options.go
@@ -6,6 +6,7 @@ package transform
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -21,6 +22,7 @@ type ControllerOptions struct {
 	extraInputs             []controller.Input
 	extraOutputs            []controller.Output
 	primaryOutputKind       controller.OutputKind
+	requeueInterval         time.Duration
 	inputFinalizers         bool
 	ignoreTearingDownInputs bool
 }
@@ -102,5 +104,13 @@ func WithOnShutdownCallback(onShutdownCallback OnShutdownCallback) ControllerOpt
 func WithOutputKind(kind controller.OutputKind) ControllerOption {
 	return func(o *ControllerOptions) {
 		o.primaryOutputKind = kind
+	}
+}
+
+// WithRequeueInterval sets the requeue interval of the transform controller.
+// Requeue is triggered by returning an error tagged SkipReconcileAndRequeue from the input processor function.
+func WithRequeueInterval(value time.Duration) ControllerOption {
+	return func(o *ControllerOptions) {
+		o.requeueInterval = value
 	}
 }

--- a/pkg/controller/generic/transform/transform.go
+++ b/pkg/controller/generic/transform/transform.go
@@ -9,3 +9,6 @@ package transform
 //
 // It's useful when next reconcile event should bring things into order.
 type SkipReconcileTag struct{}
+
+// SkipReconcileAndRequeueTag makes transform controller requeue the reconciliation call.
+type SkipReconcileAndRequeueTag struct{}


### PR DESCRIPTION
This should allow graceful restarts of the controller. For the cases when there is no way to trigger the controller on resource changes.