### PR TITLE
feat: rework controller read/write metrics

### DIFF
--- a/cmd/runtime/main.go
+++ b/cmd/runtime/main.go
@@ -81,7 +81,7 @@ func run() error {
 
 	logger := logging.DefaultLogger()
 
-	controllerRuntime, err := runtime.NewRuntime(inmemState, logger)
+	controllerRuntime, err := runtime.NewRuntime(inmemState, logger, runtime.WithMetrics(true))
 	if err != nil {
 		return fmt.Errorf("error setting up controller runtime: %w", err)
 	}

--- a/pkg/controller/protobuf/protobuf_test.go
+++ b/pkg/controller/protobuf/protobuf_test.go
@@ -45,6 +45,7 @@ func TestProtobufConformance(t *testing.T) {
 	suite := &ProtobufConformanceSuite{
 		RuntimeSuite: conformance.RuntimeSuite{
 			OutputTrackerNotImplemented: true,
+			MetricsNotImplemented:       true,
 		},
 	}
 

--- a/pkg/controller/runtime/metrics/state.go
+++ b/pkg/controller/runtime/metrics/state.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+type metricsWrapper struct {
+	innerState     state.CoreState
+	controllerName string
+}
+
+func (m *metricsWrapper) Get(ctx context.Context, pointer resource.Pointer, option ...state.GetOption) (resource.Resource, error) {
+	ControllerReads.Add(m.controllerName, 1)
+
+	return m.innerState.Get(ctx, pointer, option...)
+}
+
+func (m *metricsWrapper) List(ctx context.Context, kind resource.Kind, option ...state.ListOption) (resource.List, error) {
+	ControllerReads.Add(m.controllerName, 1)
+
+	return m.innerState.List(ctx, kind, option...)
+}
+
+func (m *metricsWrapper) Create(ctx context.Context, resource resource.Resource, option ...state.CreateOption) error {
+	ControllerWrites.Add(m.controllerName, 1)
+
+	return m.innerState.Create(ctx, resource, option...)
+}
+
+func (m *metricsWrapper) Update(ctx context.Context, newResource resource.Resource, opts ...state.UpdateOption) error {
+	ControllerWrites.Add(m.controllerName, 1)
+
+	return m.innerState.Update(ctx, newResource, opts...)
+}
+
+func (m *metricsWrapper) Destroy(ctx context.Context, pointer resource.Pointer, option ...state.DestroyOption) error {
+	ControllerWrites.Add(m.controllerName, 1)
+
+	return m.innerState.Destroy(ctx, pointer, option...)
+}
+
+func (m *metricsWrapper) Watch(ctx context.Context, pointer resource.Pointer, events chan<- state.Event, option ...state.WatchOption) error {
+	ControllerReads.Add(m.controllerName, 1)
+
+	return m.innerState.Watch(ctx, pointer, events, option...)
+}
+
+func (m *metricsWrapper) WatchKind(ctx context.Context, kind resource.Kind, events chan<- state.Event, option ...state.WatchKindOption) error {
+	ControllerReads.Add(m.controllerName, 1)
+
+	return m.innerState.WatchKind(ctx, kind, events, option...)
+}
+
+func (m *metricsWrapper) WatchKindAggregated(ctx context.Context, kind resource.Kind, c chan<- []state.Event, option ...state.WatchKindOption) error {
+	ControllerReads.Add(m.controllerName, 1)
+
+	return m.innerState.WatchKindAggregated(ctx, kind, c, option...)
+}
+
+// WrapState wraps state.State with metrics for the given controller name.
+func WrapState(controllerName string, st state.State) state.State {
+	return state.WrapCore(&metricsWrapper{
+		controllerName: controllerName,
+		innerState:     st,
+	})
+}

--- a/pkg/controller/runtime/options.go
+++ b/pkg/controller/runtime/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	// ChangeRateLimit and ChangeBurst configure rate limiting of changes performed by controllers.
 	ChangeRateLimit rate.Limit
 	ChangeBurst     int
+	MetricsEnabled  bool
 }
 
 // Option is a functional option for controller runtime.
@@ -26,10 +27,18 @@ func WithChangeRateLimit(limit rate.Limit, burst int) Option {
 	}
 }
 
+// WithMetrics enables runtime metrics to be exposed via metrics package.
+func WithMetrics(enabled bool) Option {
+	return func(options *Options) {
+		options.MetricsEnabled = enabled
+	}
+}
+
 // DefaultOptions returns default value of Options.
 func DefaultOptions() Options {
 	return Options{
 		ChangeRateLimit: rate.Inf,
 		ChangeBurst:     0,
+		MetricsEnabled:  true,
 	}
 }


### PR DESCRIPTION
Instead of incrementing the metrics on each call to read or write, wrap the underlying state and increment the metric counters only when a `CoreState` operation succeeds.

Make it possible to disable metrics in runtime.