### PR TITLE
chore: implement "handle-like" resources

### DIFF
--- a/pkg/resource/handle/handle.go
+++ b/pkg/resource/handle/handle.go
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package handle provides a way to wrap "handle/descriptor-like" resources. That is, for this resource
+// any sort of unmarsahling is not possible, but the user should define a way to marshal one into the yaml
+// representation and can define equality checks.
+package handle
+
+import (
+	"errors"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Spec should be yaml.Marshaler.
+type Spec interface {
+	yaml.Marshaler
+}
+
+// ResourceSpec wraps "handle-like" structures and adds DeepCopy and marshaling methods.
+type ResourceSpec[S Spec] struct {
+	Value S
+}
+
+// MarshalYAML implements yaml.Marshaler interface. It calls MarshalYAML on the wrapped object.
+func (spec *ResourceSpec[S]) MarshalYAML() (any, error) { return spec.Value.MarshalYAML() }
+
+// DeepCopy implemenents DeepCopyable without actually copying the object sine there is no way to actually do this.
+func (spec ResourceSpec[S]) DeepCopy() ResourceSpec[S] { return spec }
+
+// MarshalJSON implements json.Marshaler.
+func (spec *ResourceSpec[S]) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("cannot marshal handle resource into the json")
+}
+
+// MarshalProto implements ProtoMarshaler.
+func (spec *ResourceSpec[S]) MarshalProto() ([]byte, error) {
+	return nil, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface. Since we cannot unmarshal the object, we just return an error.
+func (spec *ResourceSpec[S]) UnmarshalYAML(*yaml.Node) error {
+	return errors.New("cannot unmarshal handle resource from the yaml")
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (spec *ResourceSpec[S]) UnmarshalJSON([]byte) error {
+	return errors.New("cannot unmarshal handle resource from the json")
+}
+
+// UnmarshalProto implements protobuf.ResourceUnmarshaler.
+func (spec *ResourceSpec[S]) UnmarshalProto([]byte) error {
+	return errors.New("cannot unmarshal handle resource from the protobuf")
+}
+
+// Equal implements spec equality check.
+func (spec *ResourceSpec[S]) Equal(other any) bool {
+	otherSpec, ok := other.(*ResourceSpec[S])
+	if !ok {
+		return false
+	}
+
+	if isSamePtr(spec.Value, otherSpec.Value) {
+		return true
+	}
+
+	eq, ok := any(spec.Value).(interface {
+		Equal(other S) bool
+	})
+	if !ok {
+		return false
+	}
+
+	return eq.Equal(otherSpec.Value)
+}
+
+// equalPtr is equality check function for cases where S is a pointer.
+//
+// Starting from Go 1.21 [reflect.ValueOf] no longer escapes for most cases.
+func isSamePtr[S any](a, b S) bool {
+	ar := reflect.ValueOf(a)
+
+	if ar.Kind() != reflect.Pointer {
+		// Not pointers so not equal.
+		return false
+	}
+
+	// Point to the same location.
+	return ar.Pointer() == reflect.ValueOf(b).Pointer()
+}

--- a/pkg/resource/handle/handle_test.go
+++ b/pkg/resource/handle/handle_test.go
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package handle_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/siderolabs/gen/xtesting/must"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/handle"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+)
+
+//nolint:govet
+type Handle struct {
+	mx         sync.Mutex
+	someString string
+}
+
+func (h *Handle) MarshalYAML() (any, error) {
+	h.mx.Lock()
+	defer h.mx.Unlock()
+
+	return map[string]string{
+		"someString": h.someString,
+	}, nil
+}
+
+func (h *Handle) Equal(other *Handle) bool {
+	// Locking both ensures that handle.ResourceSpec is actually handling pointers to the same object internally.
+	h.mx.Lock()
+	defer h.mx.Unlock()
+
+	other.mx.Lock()
+	defer other.mx.Unlock()
+
+	return h.someString == other.someString
+}
+
+type testSpec = handle.ResourceSpec[*Handle]
+
+type testResource = typed.Resource[testSpec, testExtension]
+
+type testExtension struct{}
+
+func (testExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             "testResource",
+		DefaultNamespace: "default",
+	}
+}
+
+func TestResourceSpec(t *testing.T) {
+	t.Parallel()
+
+	spec := testSpec{Value: &Handle{
+		someString: "my string",
+	}}
+
+	spec2 := testSpec{Value: &Handle{
+		someString: "my string",
+	}}
+
+	data, err := yaml.Marshal(spec)
+	require.NoError(t, err)
+	t.Log(string(data))
+
+	require.True(t, spec.Equal(&spec2))
+}
+
+func TestResource(t *testing.T) {
+	ctx := context.Background()
+
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+
+		defer cancel()
+	}
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+	r1 := typed.NewResource[testSpec, testExtension](
+		resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined),
+		testSpec{Value: &Handle{someString: "my string"}},
+	)
+
+	r2 := typed.NewResource[testSpec, testExtension](
+		resource.NewMetadata("default", "testResource", "aaa", resource.VersionUndefined),
+		testSpec{Value: &Handle{someString: "my string"}},
+	)
+
+	require.NoError(t, st.Create(ctx, r1))
+
+	got1 := must.Value(safe.StateGetByID[*testResource](ctx, st, "aaa"))(t)
+	got2 := must.Value(safe.StateGetByID[*testResource](ctx, st, "aaa"))(t)
+
+	require.True(t, resource.Equal(got1, got2))
+	require.Equal(t, unsafe.Pointer(got1.TypedSpec().Value), unsafe.Pointer(got2.TypedSpec().Value))
+
+	require.NoError(t, st.Destroy(ctx, got1.Metadata()))
+	require.NoError(t, st.Create(ctx, r2))
+
+	got3 := must.Value(safe.StateGetByID[*testResource](ctx, st, "aaa"))(t)
+
+	require.True(t, resource.Equal(got1, got3))
+	require.NotEqual(t, unsafe.Pointer(got1.TypedSpec().Value), unsafe.Pointer(got3.TypedSpec().Value))
+
+	enc := must.Value(resource.MarshalYAML(got3))(t)
+	out := string(must.Value(yaml.Marshal(enc))(t))
+
+	idx := strings.Index(out, "spec:")
+	require.GreaterOrEqual(t, idx, 0, "'spec:' not found in output")
+	require.Equal(t, out[idx:], `spec:
+    someString: my string
+`)
+}


### PR DESCRIPTION
This commit adds a new package named 'handle', designed for managing resources that are descriptors or handles. These handles are restricted from being transmitted from client to server. The unmarshalling of these resources is also disabled.