### PR TITLE
feat: allow setting a custom logger for the user operations

### DIFF
--- a/pkg/controller/generic/cleanup/cleanup.go
+++ b/pkg/controller/generic/cleanup/cleanup.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic"
+	"github.com/cosi-project/runtime/pkg/logging"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -85,6 +86,10 @@ func (ctrl *Controller[I]) Outputs() []controller.Output {
 
 // Run implements controller.Controller interface.
 func (ctrl *Controller[I]) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if internalLogger, ok := ctx.Value(logging.InternalLoggerContextKey{}).(*zap.Logger); ok {
+		logger = internalLogger
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/controller/generic/cleanup/cleanup_test.go
+++ b/pkg/controller/generic/cleanup/cleanup_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
 
 	"github.com/cosi-project/runtime/pkg/controller/generic/cleanup"
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/controller/runtime/options"
 	"github.com/cosi-project/runtime/pkg/future"
 	"github.com/cosi-project/runtime/pkg/logging"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -30,9 +32,10 @@ func runTest(t *testing.T, f func(ctx context.Context, t *testing.T, st state.St
 
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	logger := logging.DefaultLogger()
+	logger := logging.DefaultLogger().With(zap.String("type", "internal"))
+	userLogger := logging.DefaultLogger().With(zap.String("type", "user"))
 
-	rt, err := runtime.NewRuntime(st, logger)
+	rt, err := runtime.NewRuntime(st, logger, options.WithUserLogger(userLogger))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/controller/runtime/internal/adapter/adapter.go
+++ b/pkg/controller/runtime/internal/adapter/adapter.go
@@ -31,6 +31,7 @@ type Adapter interface {
 // Options are options for creating a new Adapter.
 type Options struct {
 	Logger         *zap.Logger
+	UserLogger     *zap.Logger
 	State          state.State
 	Cache          *cache.ResourceCache
 	DepDB          *dependency.Database

--- a/pkg/controller/runtime/internal/controllerstate/adapter.go
+++ b/pkg/controller/runtime/internal/controllerstate/adapter.go
@@ -29,6 +29,7 @@ type StateAdapter struct {
 
 	UpdateLimiter *rate.Limiter
 	Logger        *zap.Logger
+	UserLogger    *zap.Logger
 
 	Inputs  []controller.Input
 	Outputs []controller.Output

--- a/pkg/controller/runtime/options/options.go
+++ b/pkg/controller/runtime/options/options.go
@@ -6,6 +6,7 @@
 package options
 
 import (
+	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -13,6 +14,8 @@ import (
 
 // Options configures controller runtime.
 type Options struct {
+	// UserLogger is the logger to be passed to the controller.Run reconciliation function. If not set, the default runtime logger will be used.
+	UserLogger *zap.Logger
 	// CachedResources is a list of resources that should be cached by controller runtime.
 	CachedResources []CachedResource
 	// ChangeRateLimit and ChangeBurst configure rate limiting of changes performed by controllers.
@@ -64,6 +67,13 @@ func WithCachedResource(namespace resource.Namespace, typ resource.Type) Option 
 func WithWarnOnUncachedReads(warn bool) Option {
 	return func(options *Options) {
 		options.WarnOnUncachedReads = warn
+	}
+}
+
+// WithUserLogger sets the logger to be passed to the controller/qcontroller functions where the control is passed to the user (Run, Transform, MapInput, etc).
+func WithUserLogger(logger *zap.Logger) Option {
+	return func(options *Options) {
+		options.UserLogger = logger
 	}
 }
 

--- a/pkg/controller/runtime/runtime.go
+++ b/pkg/controller/runtime/runtime.go
@@ -78,6 +78,10 @@ func NewRuntime(st state.State, logger *zap.Logger, opt ...options.Option) (*Run
 		o(&runtime.options)
 	}
 
+	if runtime.options.UserLogger == nil {
+		runtime.options.UserLogger = logger
+	}
+
 	runtime.controllersCond = sync.NewCond(&runtime.controllersMu)
 
 	var err error
@@ -145,6 +149,7 @@ func (runtime *Runtime) RegisterQController(ctrl controller.QController) error {
 		ctrl,
 		adapter.Options{
 			Logger:         runtime.logger,
+			UserLogger:     runtime.options.UserLogger,
 			State:          runtime.state,
 			Cache:          runtime.cache,
 			DepDB:          runtime.depDB,

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -10,6 +10,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// InternalLoggerContextKey is the context key for the internal logger.
+type InternalLoggerContextKey struct{}
+
 // Controller creates controller zap field.
 func Controller(name string) zap.Field {
 	return zap.String("controller", name)


### PR DESCRIPTION
Allow passing a `UserLogger` to the runtime, which will be used where the control is passed to the user of the runtime, i.e., the implementor of the controllers.

With this, it is possible to have different log levels/configuration between the runtime internals and the application code that is using it as its framework.