### PR TITLE
feat: implement ContextWithTeardown method

### DIFF
--- a/pkg/controller/conformance/qcontrollers.go
+++ b/pkg/controller/conformance/qcontrollers.go
@@ -189,3 +189,125 @@ func (ctrl *QFailingController) Reconcile(ctx context.Context, _ *zap.Logger, r 
 func (ctrl *QFailingController) MapInput(context.Context, *zap.Logger, controller.QRuntime, resource.Pointer) ([]resource.Pointer, error) {
 	panic("not going to map anything")
 }
+
+// QIntToStrSleepingController converts IntResource to StrResource as a QController sleeping source seconds.
+type QIntToStrSleepingController struct {
+	SourceNamespace resource.Namespace
+	TargetNamespace resource.Namespace
+}
+
+// Name implements controller.QController interface.
+func (ctrl *QIntToStrSleepingController) Name() string {
+	return "QIntToStrSleepingController"
+}
+
+// Settings implements controller.QController interface.
+func (ctrl *QIntToStrSleepingController) Settings() controller.QSettings {
+	return controller.QSettings{
+		Inputs: []controller.Input{
+			{
+				Namespace: ctrl.SourceNamespace,
+				Type:      IntResourceType,
+				Kind:      controller.InputQPrimary,
+			},
+			{
+				Namespace: ctrl.TargetNamespace,
+				Type:      StrResourceType,
+				Kind:      controller.InputQMappedDestroyReady,
+			},
+		},
+		Outputs: []controller.Output{
+			{
+				Type: StrResourceType,
+				Kind: controller.OutputExclusive,
+			},
+		},
+		Concurrency: optional.Some(uint(1)), // use a single thread (important!)
+	}
+}
+
+// Reconcile implements controller.QController interface.
+func (ctrl *QIntToStrSleepingController) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	src, err := safe.ReaderGet[*IntResource](ctx, r, ptr)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	switch src.Metadata().Phase() {
+	case resource.PhaseTearingDown:
+		// cleanup destination resource as needed
+		dst := NewStrResource(ctrl.TargetNamespace, src.Metadata().ID(), "").Metadata()
+
+		var ready bool
+
+		ready, err = r.Teardown(ctx, dst)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return r.RemoveFinalizer(ctx, ptr, ctrl.Name())
+			}
+
+			return err
+		}
+
+		if !ready {
+			// not ready for teardown, wait
+			return nil
+		}
+
+		if err = r.Destroy(ctx, dst); err != nil {
+			return err
+		}
+
+		return r.RemoveFinalizer(ctx, ptr, ctrl.Name())
+	case resource.PhaseRunning:
+		if err = r.AddFinalizer(ctx, ptr, ctrl.Name()); err != nil {
+			return err
+		}
+
+		ctx, err = r.ContextWithTeardown(ctx, ptr)
+		if err != nil {
+			return err
+		}
+
+		delay := time.Duration(src.value.value) * time.Millisecond
+
+		logger.Info("going to sleep", zap.Duration("delay", delay))
+
+		select {
+		case <-time.After(delay):
+			logger.Info("slept", zap.Duration("delay", delay))
+		case <-ctx.Done():
+			logger.Info("interrupted", zap.Duration("delay", delay))
+
+			return ctx.Err()
+		}
+
+		strValue := strconv.Itoa(src.Value())
+
+		return safe.WriterModify(ctx, r, NewStrResource(ctrl.TargetNamespace, src.Metadata().ID(), strValue), func(r *StrResource) error {
+			r.SetValue(strValue)
+
+			return nil
+		})
+	default:
+		panic("unexpected phase")
+	}
+}
+
+// MapInput implements controller.QController interface.
+func (ctrl *QIntToStrSleepingController) MapInput(_ context.Context, _ *zap.Logger, _ controller.QRuntime, ptr resource.Pointer) ([]resource.Pointer, error) {
+	switch {
+	case ptr.Namespace() == ctrl.TargetNamespace && ptr.Type() == StrResourceType:
+		// remap output to input to recheck on finalizer removal
+		return []resource.Pointer{resource.NewMetadata(ctrl.SourceNamespace, IntResourceType, ptr.ID(), resource.VersionUndefined)}, nil
+	default:
+		return nil, fmt.Errorf("unexpected input %s", ptr)
+	}
+}

--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -113,6 +113,7 @@ type Output struct {
 type Reader interface {
 	Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
 	List(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
+	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
 }
 
 // Writer provides write access to the state.

--- a/pkg/controller/runtime/internal/cache/cache.go
+++ b/pkg/controller/runtime/internal/cache/cache.go
@@ -116,6 +116,11 @@ func (cache *ResourceCache) List(ctx context.Context, kind resource.Kind, opts .
 	return cache.getHandler(kind.Namespace(), kind.Type()).list(ctx, opts...)
 }
 
+// ContextWithTeardown implements controller.Reader interface.
+func (cache *ResourceCache) ContextWithTeardown(ctx context.Context, ptr resource.Pointer) (context.Context, error) {
+	return cache.getHandler(ptr.Namespace(), ptr.Type()).contextWithTeardown(ctx, ptr.ID())
+}
+
 // CacheAppend appends the value to the cached list.
 //
 // CacheAppend should be called in the bootstrapped phase, with resources coming in sorted by ID order.

--- a/pkg/controller/runtime/runtime_test.go
+++ b/pkg/controller/runtime/runtime_test.go
@@ -62,6 +62,8 @@ func TestRuntimeConformance(t *testing.T) {
 				options.WithCachedResource("q-str", conformance.StrResourceType),
 				options.WithCachedResource("metrics", conformance.IntResourceType),
 				options.WithCachedResource("metrics", conformance.StrResourceType),
+				options.WithCachedResource("q-sleep-in", conformance.IntResourceType),
+				options.WithCachedResource("q-sleep-out", conformance.StrResourceType),
 				options.WithWarnOnUncachedReads(true),
 			},
 		},

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -124,4 +124,10 @@ type State interface {
 
 	// RemoveFinalizer removes finalizer from resource metadata handling conflicts.
 	RemoveFinalizer(context.Context, resource.Pointer, ...resource.Finalizer) error
+
+	// ContextWithTeardown returns a new context which will be canceled when the resource is torn down or destroyed.
+	//
+	// The passed in context should be canceled, otherwise the goroutine might leak from this call.
+	// If the resource doesn't exist, the context is canceled immediately.
+	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
 }


### PR DESCRIPTION
It allows to bind a context lifetime to the lifetime of a resource, so that a context is cancelled whenever a resource is destroyed or torn down.

The implementation starts with State, and then goes into the controller runtime.

In the cache of cached resource view, the method gets a new implementation.