### PR TITLE
fix: handle non-existent output on `DestroyOutputTag`

### DIFF
--- a/pkg/controller/generic/qtransform/qtransform.go
+++ b/pkg/controller/generic/qtransform/qtransform.go
@@ -303,7 +303,7 @@ func (ctrl *QController[Input, Output]) handleOutputTearingDown(ctx context.Cont
 // handleDestroyOutput handles output destruction triggered by DestroyOutputTag.
 func (ctrl *QController[Input, Output]) handleDestroyOutput(ctx context.Context, r controller.QRuntime, mappedOut Output) error {
 	destroyReady, err := r.Teardown(ctx, mappedOut.Metadata())
-	if err != nil {
+	if err != nil && !state.IsNotFoundError(err) {
 		return fmt.Errorf("error checking if output is teardown ready: %w", err)
 	}
 


### PR DESCRIPTION
If the output does not exist at all, the `Teardown` call will fail. Handle this case by checking the error.