### PR TITLE
feat: provide an option to skip cache on reads in the controller

### DIFF
--- a/pkg/controller/qcontroller.go
+++ b/pkg/controller/qcontroller.go
@@ -58,6 +58,7 @@ type QController interface {
 // QRuntime interface as presented to the QController.
 type QRuntime interface {
 	ReaderWriter
+	UncachedReader
 }
 
 // QSettings configures runtime for the QController.

--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -26,6 +26,7 @@ type Runtime interface {
 	UpdateInputs([]Input) error
 
 	Reader
+	UncachedReader
 	Writer
 	OutputTracker
 }
@@ -114,6 +115,14 @@ type Reader interface {
 	Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
 	List(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
 	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
+}
+
+// UncachedReader provides read-only access to the state without cache.
+//
+// It might cause performance penalty, use only when necessary.
+type UncachedReader interface {
+	GetUncached(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
+	ListUncached(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
 }
 
 // Writer provides write access to the state.


### PR DESCRIPTION
Usually all reads are cached, and that cache is consistent with the watch stream and controller notifications. The cache is eventually consistent (it will catch up and notification will be delivered).

But sometimes controllers make decisions which are not reconcilable back when the cache catches up. One of the case was in Omni with automatic scaling: the controller might try to scale up the same machine set twice, and it might succeed to do so, but at the same time there's no good way sometimes to "reconcile back", as scale down is not symmetric with scale up (additional pre-checks).