### PR TITLE
feat: add generic task runner

### DIFF
--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package task
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// EqualityFunc is used to compare two task specs.
+type EqualityFunc[T any] func(x, y T) bool
+
+// Runner manages running tasks.
+type Runner[T any, S Spec[T]] struct {
+	running      map[ID]*Task[T, S]
+	equalityFunc EqualityFunc[S]
+	mu           sync.Mutex
+}
+
+// NewRunner creates a new task runner.
+func NewRunner[T any, S Spec[T]](equalityFunc EqualityFunc[S]) *Runner[T, S] {
+	if equalityFunc == nil {
+		panic("equalityFunc must not be nil")
+	}
+
+	return &Runner[T, S]{
+		running:      make(map[ID]*Task[T, S]),
+		equalityFunc: equalityFunc,
+	}
+}
+
+// NewEqualRunner creates a new task runner from spec with Equal method.
+func NewEqualRunner[S EqualSpec[T, S], T any]() *Runner[T, S] {
+	return NewRunner[T, S](func(x, y S) bool { return x.Equal(y) })
+}
+
+// Stop all running tasks.
+func (runner *Runner[T, S]) Stop() {
+	for _, task := range runner.running {
+		task.Stop()
+	}
+}
+
+// StartTask starts a new task.
+func (runner *Runner[T, S]) StartTask(ctx context.Context, logger *zap.Logger, id string, spec S, task T) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	running, ok := runner.running[id]
+
+	if ok {
+		if runner.equalityFunc(spec, running.spec) {
+			return
+		}
+
+		logger.Debug("replacing task", zap.String("task", id))
+
+		runner.stopTask(id)
+	}
+
+	runner.running[id] = New(logger, spec, task)
+
+	logger.Debug("starting task", zap.String("task", id))
+	runner.running[id].Start(ctx)
+}
+
+// StopTask stop the running task.
+func (runner *Runner[T, S]) StopTask(logger *zap.Logger, id string) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	logger.Debug("stopping task", zap.String("task", id))
+
+	runner.stopTask(id)
+}
+
+func (runner *Runner[T, S]) stopTask(id string) {
+	if _, ok := runner.running[id]; !ok {
+		return
+	}
+
+	runner.running[id].Stop()
+	delete(runner.running, id)
+}
+
+// Reconcile running tasks.
+func (runner *Runner[T, S]) Reconcile(ctx context.Context, logger *zap.Logger, shouldRun map[ID]S, in T) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	// stop running tasks which shouldn't run
+	for id := range runner.running {
+		if _, exists := shouldRun[id]; !exists {
+			logger.Debug("stopping task", zap.String("task", id))
+
+			runner.stopTask(id)
+		} else if !runner.equalityFunc(shouldRun[id], runner.running[id].Spec()) {
+			logger.Debug("replacing task", zap.String("task", id))
+
+			runner.stopTask(id)
+		}
+	}
+
+	// start tasks which aren't running
+	for id := range shouldRun {
+		if _, exists := runner.running[id]; !exists {
+			runner.running[id] = New(logger, shouldRun[id], in)
+
+			logger.Debug("starting task", zap.String("task", id))
+			runner.running[id].Start(ctx)
+		}
+	}
+}

--- a/pkg/task/runner_test.go
+++ b/pkg/task/runner_test.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package task_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/cosi-project/runtime/pkg/task"
+)
+
+func TestRunner(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	assert := assert.New(t)
+
+	in := &taskInputMock{
+		commandCh: make(chan taskCommand),
+	}
+
+	assertTask := func(id string, expectedRunning bool) {
+		assert.Eventually(func() bool {
+			running, _ := in.runningTasks.Get(id)
+
+			return running == expectedRunning
+		}, time.Second, time.Millisecond)
+	}
+
+	runner := task.NewRunner(func(a, b taskSpec) bool {
+		return a == b
+	})
+
+	runner.Reconcile(ctx, logger, nil, in)
+
+	runner.Reconcile(ctx, logger, map[task.ID]taskSpec{
+		"task1": "task1",
+		"task2": "task2",
+	}, in)
+
+	assertTask("task1", true)
+	assertTask("task2", true)
+
+	runner.Reconcile(ctx, logger, map[task.ID]taskSpec{
+		"task2": "task2",
+	}, in)
+
+	assertTask("task1", false)
+	assertTask("task2", true)
+
+	runner.Reconcile(ctx, logger, map[task.ID]taskSpec{
+		"task2": "task3", // a bit of hack with different IDs to test the replace logic
+		"task4": "task4",
+	}, in)
+
+	assertTask("task2", false)
+	assertTask("task3", true)
+	assertTask("task4", true)
+
+	runner.Stop()
+
+	assertTask("task3", false)
+	assertTask("task4", false)
+}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package task implements generic controller tasks running in goroutines.
+package task
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.uber.org/zap"
+)
+
+// ID is a task ID.
+type ID = string
+
+// Spec configures a task.
+type Spec[T any] interface {
+	ID() ID
+	RunTask(ctx context.Context, logger *zap.Logger, in T) error
+}
+
+// Task is a generic controller task that can run in a goroutine with restarts and panic handling.
+type Task[T any, S Spec[T]] struct {
+	spec S
+	in   T
+
+	logger *zap.Logger
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// New creates a new task.
+func New[T any, S Spec[T]](logger *zap.Logger, spec S, in T) *Task[T, S] {
+	return &Task[T, S]{
+		spec:   spec,
+		in:     in,
+		logger: logger.With(zap.String("task", spec.ID())),
+	}
+}
+
+// Spec returns the task spec.
+func (task *Task[T, S]) Spec() S {
+	return task.spec
+}
+
+// Start the task in a separate goroutine.
+func (task *Task[T, S]) Start(ctx context.Context) {
+	task.wg.Add(1)
+
+	ctx, task.cancel = context.WithCancel(ctx)
+
+	go func() {
+		defer task.wg.Done()
+
+		task.runWithRestarts(ctx)
+	}()
+}
+
+func (task *Task[T, S]) runWithRestarts(ctx context.Context) {
+	backoff := backoff.NewExponentialBackOff()
+
+	// disable number of retries limit
+	backoff.MaxElapsedTime = 0
+
+	for ctx.Err() == nil {
+		err := task.runWithPanicHandler(ctx)
+
+		// finished without an error
+		if err == nil {
+			task.logger.Info("task finished")
+
+			return
+		}
+
+		interval := backoff.NextBackOff()
+
+		task.logger.Error("restarting task", zap.Duration("interval", interval), zap.Error(err))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
+func (task *Task[T, S]) runWithPanicHandler(ctx context.Context) (err error) { //nolint:nonamedreturns
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %v", p)
+
+			task.logger.Error("task panicked", zap.Stack("stack"), zap.Error(err))
+		}
+	}()
+
+	return task.spec.RunTask(ctx, task.logger, task.in)
+}
+
+// Stop the task waiting for it to finish.
+func (task *Task[T, S]) Stop() {
+	task.cancel()
+
+	task.wg.Wait()
+}
+
+// EqualSpec is like [Spec] but it requires an Equal method from the spec.
+type EqualSpec[T any, S Spec[T]] interface {
+	Spec[T]
+	Equal(S) bool
+}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package task_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/gen/containers"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/cosi-project/runtime/pkg/task"
+)
+
+type taskCommand struct {
+	returnWithError error
+	panicNow        bool
+}
+
+type taskInputMock struct {
+	commandCh    chan taskCommand
+	runningTasks containers.ConcurrentMap[task.ID, bool]
+}
+
+type taskSpec task.ID
+
+func (spec taskSpec) ID() task.ID {
+	return task.ID(spec)
+}
+
+func (spec taskSpec) RunTask(ctx context.Context, _ *zap.Logger, in *taskInputMock) error {
+	in.runningTasks.Set(task.ID(spec), true)
+	defer in.runningTasks.Set(task.ID(spec), false)
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case cmd := <-in.commandCh:
+		if cmd.panicNow {
+			panic("panic")
+		}
+
+		return cmd.returnWithError
+	}
+}
+
+func TestTask(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	assert := assert.New(t)
+
+	in := &taskInputMock{
+		commandCh: make(chan taskCommand),
+	}
+
+	assertTask := func(id string, expectedRunning bool) {
+		assert.Eventually(func() bool {
+			running, _ := in.runningTasks.Get(id)
+
+			return running == expectedRunning
+		}, 3*time.Second, time.Millisecond)
+	}
+
+	t1 := task.New(logger, taskSpec("task1"), in)
+	t1.Start(ctx)
+
+	assertTask("task1", true)
+
+	// should restart on panic
+	in.commandCh <- taskCommand{
+		panicNow: true,
+	}
+
+	assertTask("task1", false)
+	assertTask("task1", true)
+
+	// short restart on error
+	in.commandCh <- taskCommand{
+		returnWithError: errors.New("failed"),
+	}
+
+	assertTask("task1", false)
+	assertTask("task1", true)
+
+	t1.Stop()
+	assertTask("task1", false)
+}


### PR DESCRIPTION
Pull the generic task runner used in Omni (https://github.com/siderolabs/omni/tree/85424da98eed1a8c49d39e7d51d57583d607e40b/internal/backend/runtime/omni/controllers/omni/internal/task) into the runtime.