### PR TITLE
chore: add two functions to the `safe` package

### DIFF
--- a/pkg/resource/rtestutils/assertions.go
+++ b/pkg/resource/rtestutils/assertions.go
@@ -225,11 +225,12 @@ func AssertNoResource[R ResourceWithRD](
 		case ev = <-watchCh:
 		}
 
-		switch ev.Type { //nolint:exhaustive
+		switch ev.Type {
 		case state.Destroyed:
 			return
 		case state.Errored:
 			require.NoError(ev.Error)
+		case state.Created, state.Updated, state.Bootstrapped:
 		}
 	}
 }
@@ -265,7 +266,7 @@ func AssertLength[R ResourceWithRD](ctx context.Context, t *testing.T, st state.
 	for {
 		select {
 		case event := <-watchCh:
-			switch event.Type { //nolint:exhaustive
+			switch event.Type {
 			case state.Created:
 				length++
 			case state.Destroyed:
@@ -274,6 +275,7 @@ func AssertLength[R ResourceWithRD](ctx context.Context, t *testing.T, st state.
 				bootstrapped = true
 			case state.Errored:
 				require.NoError(event.Error)
+			case state.Updated:
 			}
 
 			if bootstrapped && length == expectedLength {

--- a/pkg/safe/state.go
+++ b/pkg/safe/state.go
@@ -282,6 +282,9 @@ func (l *List[T]) Find(fn func(T) bool) (T, bool) {
 	return zero, false
 }
 
+// Swap swaps the elements with indexes i and j.
+func (l *List[T]) Swap(i, j int) { l.list.Items[i], l.list.Items[j] = l.list.Items[j], l.list.Items[i] }
+
 // Iterator returns a new iterator over the list.
 func (l *List[T]) Iterator() ListIterator[T] {
 	return ListIterator[T]{pos: 0, list: *l}

--- a/pkg/safe/util.go
+++ b/pkg/safe/util.go
@@ -13,7 +13,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 )
 
-// Map applies the given function to each element of the list and returns a new list with the results.
+// Map applies the given function to each element of the list and returns a new slice with the results. It
+// returns an error if the given function had returned an error.
 func Map[T any, R any](list List[T], fn func(T) (R, error)) ([]R, error) {
 	result := make([]R, 0, list.Len())
 
@@ -27,6 +28,17 @@ func Map[T any, R any](list List[T], fn func(T) (R, error)) ([]R, error) {
 	}
 
 	return result, nil
+}
+
+// ToSlice applies the given function to each element of the list and returns a new slice with the results.
+func ToSlice[T any, R any](list List[T], fn func(T) R) []R {
+	result := make([]R, 0, list.Len())
+
+	for _, item := range list.list.Items {
+		result = append(result, fn(item.(T))) //nolint:forcetypeassert
+	}
+
+	return result
 }
 
 // Input returns a controller.Input for the given resource.


### PR DESCRIPTION
• Add `Swap` method to the `safe.List` type, so it can be sorted in place. 
• Add `ToSlice` function which converts `safe.List` to slice using the provided function.