### PR TITLE
fix: call reset backoff in the cleanup controller

### DIFF
--- a/pkg/controller/generic/cleanup/cleanup.go
+++ b/pkg/controller/generic/cleanup/cleanup.go
@@ -115,6 +115,8 @@ func (ctrl *Controller[I]) Run(ctx context.Context, r controller.Runtime, logger
 		if multiErr != nil {
 			return fmt.Errorf("cleanup controller %q failed: %w", ctrl.Name(), multiErr)
 		}
+
+		r.ResetRestartBackoff()
 	}
 }
 


### PR DESCRIPTION
Otherwise it accumulates the backoff forever.