### PR TITLE
fix: make inmem bookmarks random for each run

### DIFF
--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -137,3 +137,15 @@ func errPhaseConflict(r resource.Reference, expectedPhase resource.Phase) error 
 		},
 	}
 }
+
+// ErrInvalidWatchBookmark should be implemented by "invalid watch bookmark" errors.
+type ErrInvalidWatchBookmark interface {
+	InvalidWatchBookmarkError()
+}
+
+// IsInvalidWatchBookmarkError checks if err is invalid watch bookmark.
+func IsInvalidWatchBookmarkError(err error) bool {
+	var i ErrInvalidWatchBookmark
+
+	return errors.As(err, &i)
+}

--- a/pkg/state/impl/inmem/errors.go
+++ b/pkg/state/impl/inmem/errors.go
@@ -5,6 +5,7 @@
 package inmem
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -99,4 +100,16 @@ func ErrPhaseConflict(r resource.Reference, expectedPhase resource.Phase) error 
 			resource: r,
 		},
 	}
+}
+
+//nolint:errname
+type eInvalidWatchBookmark struct {
+	error
+}
+
+func (eInvalidWatchBookmark) InvalidWatchBookmarkError() {}
+
+// ErrInvalidWatchBookmark generates error compatible with state.ErrInvalidWatchBookmark.
+var ErrInvalidWatchBookmark = eInvalidWatchBookmark{
+	errors.New("invalid watch bookmark"),
 }

--- a/pkg/state/impl/inmem/errors_test.go
+++ b/pkg/state/impl/inmem/errors_test.go
@@ -32,4 +32,6 @@ func TestErrors(t *testing.T) {
 
 	assert.True(t, state.IsConflictError(inmem.ErrAlreadyExists(resource.NewMetadata("ns", "a", "b", resource.VersionUndefined)), state.WithResourceType("a"), state.WithResourceNamespace("ns")))
 	assert.False(t, state.IsConflictError(inmem.ErrAlreadyExists(resource.NewMetadata("ns", "a", "b", resource.VersionUndefined)), state.WithResourceType("z"), state.WithResourceNamespace("ns")))
+
+	assert.True(t, state.IsInvalidWatchBookmarkError(inmem.ErrInvalidWatchBookmark))
 }

--- a/pkg/state/protobuf/client/client.go
+++ b/pkg/state/protobuf/client/client.go
@@ -340,7 +340,12 @@ func (adapter *Adapter) Watch(ctx context.Context, resourcePointer resource.Poin
 	// receive first (empty) watch event
 	_, err = cli.Recv()
 	if err != nil {
-		return err
+		switch status.Code(err) { //nolint:exhaustive
+		case codes.FailedPrecondition:
+			return eInvalidWatchBookmark{err}
+		default:
+			return err
+		}
 	}
 
 	go adapter.watchAdapter(ctx, cli, ch, nil, opts.UnmarshalOptions.SkipProtobufUnmarshal, req)
@@ -388,7 +393,12 @@ func (adapter *Adapter) WatchKind(ctx context.Context, resourceKind resource.Kin
 	// receive first (empty) watch event
 	_, err = cli.Recv()
 	if err != nil {
-		return err
+		switch status.Code(err) { //nolint:exhaustive
+		case codes.FailedPrecondition:
+			return eInvalidWatchBookmark{err}
+		default:
+			return err
+		}
 	}
 
 	go adapter.watchAdapter(ctx, cli, ch, nil, opts.UnmarshalOptions.SkipProtobufUnmarshal, req)
@@ -437,7 +447,12 @@ func (adapter *Adapter) WatchKindAggregated(ctx context.Context, resourceKind re
 	// receive first (empty) watch event
 	_, err = cli.Recv()
 	if err != nil {
-		return err
+		switch status.Code(err) { //nolint:exhaustive
+		case codes.FailedPrecondition:
+			return eInvalidWatchBookmark{err}
+		default:
+			return err
+		}
 	}
 
 	go adapter.watchAdapter(ctx, cli, nil, ch, opts.UnmarshalOptions.SkipProtobufUnmarshal, req)
@@ -526,7 +541,12 @@ func (adapter *Adapter) watchAdapter(
 
 			_, err = cli.Recv()
 			if err != nil {
-				continue
+				switch status.Code(err) { //nolint:exhaustive
+				case codes.FailedPrecondition: // abort retries on invalid watch bookmark
+					return nil, eInvalidWatchBookmark{err}
+				default:
+					continue
+				}
 			}
 
 			msg, err = cli.Recv()

--- a/pkg/state/protobuf/client/errors.go
+++ b/pkg/state/protobuf/client/errors.go
@@ -38,3 +38,10 @@ type ePhaseConflict struct {
 }
 
 func (ePhaseConflict) PhaseConflictError() {}
+
+//nolint:errname
+type eInvalidWatchBookmark struct {
+	error
+}
+
+func (eInvalidWatchBookmark) InvalidWatchBookmarkError() {}

--- a/pkg/state/protobuf/server/server.go
+++ b/pkg/state/protobuf/server/server.go
@@ -328,7 +328,12 @@ func (server *State) Watch(req *v1alpha1.WatchRequest, srv v1alpha1.State_WatchS
 	}
 
 	if err != nil {
-		return err
+		switch {
+		case state.IsInvalidWatchBookmarkError(err):
+			return status.Error(codes.FailedPrecondition, err.Error())
+		default:
+			return err
+		}
 	}
 
 	// send empty event to signal that watch is ready


### PR DESCRIPTION
As inmem storage is not persisted, make sure watch bookmark from one run doesn't work with another run.

This still allows watches to be restarted on connection failures, but if the watch is restarted on a program restart, bookmark won't match anymore.