### PR TITLE
feat: add `WithIgnoreTeardownWhile` to `qtransform` controllers

### DIFF
--- a/pkg/controller/generic/qtransform/qtransform.go
+++ b/pkg/controller/generic/qtransform/qtransform.go
@@ -200,19 +200,21 @@ func (ctrl *QController[Input, Output]) Reconcile(ctx context.Context, logger *z
 
 		// if there's an option to ignore finalizers, check if we should ignore tearing down
 		// and perform "normal" reconcile instead
-		if ctrl.options.leftoverFinalizers != nil {
+		if ctrl.options.ignoreTeardownUntilFinalizers != nil || ctrl.options.ignoreTeardownWhileFinalizers != nil {
 			for _, fin := range *in.Metadata().Finalizers() {
 				if fin == ctrl.ControllerName {
 					continue
 				}
 
-				if _, present := ctrl.options.leftoverFinalizers[fin]; present {
+				if _, present = ctrl.options.ignoreTeardownUntilFinalizers[fin]; present {
 					continue
 				}
 
-				ignoreTearingDown = true
+				if _, present = ctrl.options.ignoreTeardownWhileFinalizers[fin]; present {
+					ignoreTearingDown = true
 
-				break
+					break
+				}
 			}
 		}
 

--- a/pkg/controller/generic/qtransform/qtransform_test.go
+++ b/pkg/controller/generic/qtransform/qtransform_test.go
@@ -417,6 +417,7 @@ func TestDestroy(t *testing.T) {
 	})
 }
 
+//nolint:dupl
 func TestDestroyWithIgnoreTeardownUntil(t *testing.T) {
 	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
 		require.NoError(t, runtime.RegisterQController(NewABCController(qtransform.WithIgnoreTeardownUntil("extra-finalizer"))))
@@ -460,6 +461,56 @@ func TestDestroyWithIgnoreTeardownUntil(t *testing.T) {
 
 		// remove extra-finalizer
 		require.NoError(t, st.RemoveFinalizer(ctx, NewA("2", ASpec{}).Metadata(), "extra-finalizer"))
+
+		// the input '2' should be destroyed now
+		rtestutils.Destroy[*A](ctx, t, st, []resource.ID{"2"})
+	})
+}
+
+//nolint:dupl
+func TestDestroyWithIgnoreTeardownWhile(t *testing.T) {
+	setup(t, func(ctx context.Context, st state.State, runtime *runtime.Runtime) {
+		require.NoError(t, runtime.RegisterQController(NewABCController(qtransform.WithIgnoreTeardownWhile("extra-finalizer"))))
+
+		for _, a := range []*A{
+			NewA("1", ASpec{}),
+			NewA("2", ASpec{}),
+			NewA("3", ASpec{}),
+		} {
+			require.NoError(t, st.Create(ctx, a))
+		}
+
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-1", "transformed-2", "transformed-3"}, func(*B, *assert.Assertions) {})
+
+		// destroy without extra finalizers should work immediately
+		rtestutils.Destroy[*A](ctx, t, st, []resource.ID{"1"})
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-1")
+
+		// add two finalizers to '2'
+		require.NoError(t, st.AddFinalizer(ctx, NewA("2", ASpec{}).Metadata(), "extra-finalizer", "other-finalizer"))
+
+		// teardown input '2'
+		_, err := st.Teardown(ctx, NewA("2", ASpec{}).Metadata())
+		require.NoError(t, err)
+
+		// the output 'transformed-2' should not be torn down yet
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"transformed-2", "transformed-3"}, func(r *B, asrt *assert.Assertions) {
+			asrt.Equal(resource.PhaseRunning, r.Metadata().Phase())
+		})
+
+		// remove extra-finalizer
+		require.NoError(t, st.RemoveFinalizer(ctx, NewA("2", ASpec{}).Metadata(), "extra-finalizer"))
+		//
+		// the output 'transformed-2' should be destroyed now
+		rtestutils.AssertNoResource[*B](ctx, t, st, "transformed-2")
+		//
+		// the input '2' should no longer have controller finalizer
+		rtestutils.AssertResources(ctx, t, st, []resource.ID{"2"}, func(r *A, asrt *assert.Assertions) {
+			asrt.False(r.Metadata().Finalizers().Has("QTransformABCController"))
+		})
+
+		// remove other-finalizer
+		require.NoError(t, st.RemoveFinalizer(ctx, NewA("2", ASpec{}).Metadata(), "other-finalizer"))
 
 		// the input '2' should be destroyed now
 		rtestutils.Destroy[*A](ctx, t, st, []resource.ID{"2"})


### PR DESCRIPTION
This is the opposite of `WithIgnoreTeardownUntil` - the runtime will not run teardown while the specified finalizers are still on the input resource. This further facilitates the ordering of "which controller runs its finalizerRemoval before/after which one".

The idea came up from our discussion with @Unix4ever.