### PR TITLE
fix: ensure that controller conformance tests work over net too

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,4 +47,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a // indirect
 )
 
-retract v0.4.7 // Wait with locked mutex leads to the deadlock
+retract (
+	v0.7.3 // Typo in the test type result
+	v0.4.7 // Wait with locked mutex leads to the deadlock
+)

--- a/pkg/controller/conformance/resources.go
+++ b/pkg/controller/conformance/resources.go
@@ -61,7 +61,7 @@ func NewStrResource(ns resource.Namespace, id resource.ID, value string) *StrRes
 type strSpec struct{ ValueGetSet[string] } //nolint:recvcheck
 
 func (s *strSpec) FromProto(bytes []byte)       { s.value = string(bytes) }
-func (s strSpec) MarshalProto() ([]byte, error) { return []byte(s.value + "stuff"), nil }
+func (s strSpec) MarshalProto() ([]byte, error) { return []byte(s.value), nil }
 
 // SentenceResourceType is the type of SentenceResource.
 const SentenceResourceType = resource.Type("test/sentence")


### PR DESCRIPTION
Otherwise, buggy `FromProto|MarshalProto` methods wil go unnoticed.