### PR TITLE
fix: do not overwrite error in watch retry

### DIFF
--- a/pkg/state/protobuf/client/client.go
+++ b/pkg/state/protobuf/client/client.go
@@ -515,8 +515,8 @@ func (adapter *Adapter) watchAdapter(
 			// lastBookmark is the last seen bookmark
 			//
 			// quick check for context canceled, no need to retry
-			if err = ctx.Err(); err != nil {
-				return nil, err
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
 			}
 
 			delay := backoff.NextBackOff()


### PR DESCRIPTION
Do not overwrite the watch error with the error from the context when checking for the context error, so that if we hit the maximum retry attempts, the error will be printed correctly.