### PR TITLE
feat: implement `TeardownAndDestroy` helper function

### DIFF
--- a/pkg/state/options.go
+++ b/pkg/state/options.go
@@ -152,6 +152,21 @@ func WithDestroyOwner(owner string) DestroyOption {
 	}
 }
 
+// TeardownAndDestroyOption builds TeardownAndDestroyOption.
+type TeardownAndDestroyOption func(*TeardownAndDestroyOptions)
+
+// TeardownAndDestroyOptions for the CoreState.TeardownAndDestroy function.
+type TeardownAndDestroyOptions struct {
+	Owner string
+}
+
+// WithTeardownAndDestroyOwner checks an owner on the object being destroyed.
+func WithTeardownAndDestroyOwner(owner string) TeardownAndDestroyOption {
+	return func(opts *TeardownAndDestroyOptions) {
+		opts.Owner = owner
+	}
+}
+
 // WatchOptions for the CoreState.Watch function.
 type WatchOptions struct {
 	StartFromBookmark Bookmark

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -137,4 +137,11 @@ type State interface {
 	// The passed in context should be canceled, otherwise the goroutine might leak from this call.
 	// If the resource doesn't exist, the context is canceled immediately.
 	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
+
+	// TeardownAndDestroy a resource.
+	//
+	// If a resource doesn't exist, error is returned.
+	// It's not an error to tear down a resource which is already being torn down.
+	// The call blocks until all resource finalizers are empty.
+	TeardownAndDestroy(context.Context, resource.Pointer, ...TeardownAndDestroyOption) error
 }


### PR DESCRIPTION
The function combines `Teardown`, `Watch` for finalizers to be empty and `Destroy` calls.

Fixes: https://github.com/siderolabs/omni/issues/1137