### PR TITLE
chore: use `resource.Resource` as the base type in the `safe.List`

### DIFF
--- a/pkg/safe/state.go
+++ b/pkg/safe/state.go
@@ -201,12 +201,12 @@ func StateWatchKind[T resource.Resource](ctx context.Context, st state.CoreState
 }
 
 // List is a type safe wrapper around resource.List.
-type List[T any] struct {
+type List[T resource.Resource] struct {
 	list resource.List
 }
 
 // NewList creates a new List.
-func NewList[T any](list resource.List) List[T] {
+func NewList[T resource.Resource](list resource.List) List[T] {
 	return List[T]{list}
 }
 
@@ -316,8 +316,19 @@ func (l *List[T]) All() iter.Seq[T] {
 	}
 }
 
+// Pointers returns a new rangefunc iterator over each resource pointer in the list.
+func (l *List[T]) Pointers() iter.Seq[resource.Pointer] {
+	return func(yield func(resource.Pointer) bool) {
+		for i := range l.list.Items {
+			if !yield(l.Get(i).Metadata()) {
+				return
+			}
+		}
+	}
+}
+
 // ListIterator is a generic iterator over resource.Resource slice.
-type ListIterator[T any] struct {
+type ListIterator[T resource.Resource] struct {
 	list List[T]
 	pos  int
 }
@@ -325,7 +336,7 @@ type ListIterator[T any] struct {
 // IteratorFromList returns a new iterator over the given list.
 //
 // Deprecated: use [List.All] instead.
-func IteratorFromList[T any](list List[T]) ListIterator[T] {
+func IteratorFromList[T resource.Resource](list List[T]) ListIterator[T] {
 	return ListIterator[T]{pos: 0, list: list}
 }
 

--- a/pkg/safe/util.go
+++ b/pkg/safe/util.go
@@ -15,7 +15,7 @@ import (
 
 // Map applies the given function to each element of the list and returns a new slice with the results. It
 // returns an error if the given function had returned an error.
-func Map[T any, R any](list List[T], fn func(T) (R, error)) ([]R, error) {
+func Map[T, R resource.Resource](list List[T], fn func(T) (R, error)) ([]R, error) {
 	result := make([]R, 0, list.Len())
 
 	for _, item := range list.list.Items {
@@ -31,7 +31,7 @@ func Map[T any, R any](list List[T], fn func(T) (R, error)) ([]R, error) {
 }
 
 // ToSlice applies the given function to each element of the list and returns a new slice with the results.
-func ToSlice[T any, R any](list List[T], fn func(T) R) []R {
+func ToSlice[T, R resource.Resource](list List[T], fn func(T) R) []R {
 	result := make([]R, 0, list.Len())
 
 	for _, item := range list.list.Items {


### PR DESCRIPTION
With that change also introduce the method for getting all resources from the list as `resource.Pointer` iterator.