### PR TITLE
fix: allow any type in the `safe.ToSlice` and `safe.Map` methods

### DIFF
--- a/pkg/safe/util.go
+++ b/pkg/safe/util.go
@@ -15,7 +15,7 @@ import (
 
 // Map applies the given function to each element of the list and returns a new slice with the results. It
 // returns an error if the given function had returned an error.
-func Map[T, R resource.Resource](list List[T], fn func(T) (R, error)) ([]R, error) {
+func Map[T resource.Resource, R any](list List[T], fn func(T) (R, error)) ([]R, error) {
 	result := make([]R, 0, list.Len())
 
 	for _, item := range list.list.Items {
@@ -31,7 +31,7 @@ func Map[T, R resource.Resource](list List[T], fn func(T) (R, error)) ([]R, erro
 }
 
 // ToSlice applies the given function to each element of the list and returns a new slice with the results.
-func ToSlice[T, R resource.Resource](list List[T], fn func(T) R) []R {
+func ToSlice[T resource.Resource, R any](list List[T], fn func(T) R) []R {
 	result := make([]R, 0, list.Len())
 
 	for _, item := range list.list.Items {


### PR DESCRIPTION
For these two methods it actually makes sense to have any return type there.