### PR TITLE
feat: move `Modify` implementation so State

### DIFF
--- a/pkg/state/options.go
+++ b/pkg/state/options.go
@@ -122,6 +122,13 @@ func WithExpectedPhaseAny() UpdateOption {
 	}
 }
 
+// WithUpdateOptions sets update options for the update request.
+func WithUpdateOptions(opts UpdateOptions) UpdateOption {
+	return func(options *UpdateOptions) {
+		*options = opts
+	}
+}
+
 // TeardownOptions for the CoreState.Teardown function.
 type TeardownOptions struct {
 	Owner string

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -144,4 +144,14 @@ type State interface {
 	// It's not an error to tear down a resource which is already being torn down.
 	// The call blocks until all resource finalizers are empty.
 	TeardownAndDestroy(context.Context, resource.Pointer, ...TeardownAndDestroyOption) error
+
+	// Modify modifies an existing resource or creates a new one.
+	//
+	// It is a shorthand for Get+UpdateWithConflicts+Create.
+	Modify(ctx context.Context, emptyResource resource.Resource, updateFunc func(resource.Resource) error, options ...UpdateOption) error
+
+	// ModifyWithResult modifies an existing resource or creates a new one.
+	//
+	// It is a shorthand for Get+UpdateWithConflicts+Create.
+	ModifyWithResult(ctx context.Context, emptyResource resource.Resource, updateFunc func(resource.Resource) error, options ...UpdateOption) (resource.Resource, error)
 }


### PR DESCRIPTION
This moved `Modify` from controller adapter to state, allowing Modify with plain State.

Fixes https://github.com/siderolabs/omni/issues/1136