### PR TITLE
refactor: split parts of the adapter as owned.State

### DIFF
--- a/pkg/controller/runtime.go
+++ b/pkg/controller/runtime.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/owned"
 )
 
 // ReconcileEvent is a signal for controller to reconcile its resources.
@@ -111,11 +112,7 @@ type Output struct {
 // Reader provides read-only access to the state.
 //
 // Interface [state.State] also satisfies this interface.
-type Reader interface {
-	Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
-	List(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
-	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
-}
+type Reader = owned.Reader
 
 // UncachedReader provides read-only access to the state without cache.
 //
@@ -128,23 +125,10 @@ type UncachedReader interface {
 // Writer provides write access to the state.
 //
 // Only output objects can be written to by the controller.
-type Writer interface {
-	Create(context.Context, resource.Resource) error
-	Update(context.Context, resource.Resource) error
-	Modify(context.Context, resource.Resource, func(resource.Resource) error, ...ModifyOption) error
-	ModifyWithResult(context.Context, resource.Resource, func(resource.Resource) error, ...ModifyOption) (resource.Resource, error)
-	Teardown(context.Context, resource.Pointer, ...DeleteOption) (bool, error)
-	Destroy(context.Context, resource.Pointer, ...DeleteOption) error
-
-	AddFinalizer(context.Context, resource.Pointer, ...resource.Finalizer) error
-	RemoveFinalizer(context.Context, resource.Pointer, ...resource.Finalizer) error
-}
+type Writer = owned.Writer
 
 // ReaderWriter combines Reader and Writer interfaces.
-type ReaderWriter interface {
-	Reader
-	Writer
-}
+type ReaderWriter = owned.ReaderWriter
 
 // OutputTracker provides automatic cleanup of the outputs based on the calls to Modify function.
 //
@@ -159,64 +143,22 @@ type OutputTracker interface {
 }
 
 // DeleteOption for operation Teardown/Destroy.
-type DeleteOption func(*DeleteOptions)
-
-// DeleteOptions for operation Teardown/Destroy.
-type DeleteOptions struct {
-	Owner *string
-}
+type DeleteOption = owned.DeleteOption
 
 // WithOwner allows to specify owner of the resource.
 func WithOwner(owner string) DeleteOption {
-	return func(o *DeleteOptions) {
-		o.Owner = &owner
-	}
-}
-
-// ToDeleteOptions converts variadic options to DeleteOptions.
-func ToDeleteOptions(opts ...DeleteOption) DeleteOptions {
-	var options DeleteOptions
-
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	return options
+	return owned.WithOwner(owner)
 }
 
 // ModifyOption for operation Modify.
-type ModifyOption func(*ModifyOptions)
-
-// ModifyOptions for operation Modify.
-type ModifyOptions struct {
-	ExpectedPhase *resource.Phase
-}
+type ModifyOption = owned.ModifyOption
 
 // WithExpectedPhase allows to specify expected phase of the resource.
 func WithExpectedPhase(phase resource.Phase) ModifyOption {
-	return func(o *ModifyOptions) {
-		o.ExpectedPhase = &phase
-	}
+	return owned.WithExpectedPhase(phase)
 }
 
 // WithExpectedPhaseAny allows to specify any phase of the resource.
 func WithExpectedPhaseAny() ModifyOption {
-	return func(o *ModifyOptions) {
-		o.ExpectedPhase = nil
-	}
-}
-
-// ToModifyOptions converts variadic options to ModifyOptions.
-func ToModifyOptions(opts ...ModifyOption) ModifyOptions {
-	phase := resource.PhaseRunning
-
-	options := ModifyOptions{
-		ExpectedPhase: &phase,
-	}
-
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	return options
+	return owned.WithExpectedPhaseAny()
 }

--- a/pkg/controller/runtime/internal/qruntime/qruntime.go
+++ b/pkg/controller/runtime/internal/qruntime/qruntime.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/runtime/metrics"
 	"github.com/cosi-project/runtime/pkg/logging"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state/owned"
 )
 
 type resourceNamespaceType struct {
@@ -105,7 +106,7 @@ func NewAdapter(
 
 	return &Adapter{
 		StateAdapter: controllerstate.StateAdapter{
-			State:               state,
+			OwnedState:          owned.New(state, name),
 			Cache:               adapterOptions.Cache,
 			Name:                name,
 			UpdateLimiter:       rate.NewLimiter(adapterOptions.RuntimeOptions.ChangeRateLimit, adapterOptions.RuntimeOptions.ChangeBurst),

--- a/pkg/controller/runtime/internal/rruntime/rruntime.go
+++ b/pkg/controller/runtime/internal/rruntime/rruntime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/runtime/metrics"
 	"github.com/cosi-project/runtime/pkg/controller/runtime/options"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state/owned"
 )
 
 // Adapter connects common controller-runtime and rruntime controller.
@@ -64,7 +65,7 @@ func NewAdapter(
 	adapter := &Adapter{
 		StateAdapter: controllerstate.StateAdapter{
 			Name:                ctrl.Name(),
-			State:               state,
+			OwnedState:          owned.New(state, ctrl.Name()),
 			Cache:               adapterOptions.Cache,
 			Outputs:             slices.Clone(ctrl.Outputs()),
 			UpdateLimiter:       rate.NewLimiter(adapterOptions.RuntimeOptions.ChangeRateLimit, adapterOptions.RuntimeOptions.ChangeBurst),

--- a/pkg/state/owned/owned.go
+++ b/pkg/state/owned/owned.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package owned contains the wrapping state for enforcing ownership.
+package owned
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// Reader provides read-only access to the state.
+//
+// Is is identical to the [state.State] interface, and it does not
+// provide any additional methods.
+type Reader interface {
+	Get(context.Context, resource.Pointer, ...state.GetOption) (resource.Resource, error)
+	List(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
+	ContextWithTeardown(context.Context, resource.Pointer) (context.Context, error)
+}
+
+// Writer provides write access to the state.
+//
+// Write methods enforce that the resources are owned by the designated owner.
+type Writer interface {
+	Create(context.Context, resource.Resource) error
+	Update(context.Context, resource.Resource) error
+	Modify(context.Context, resource.Resource, func(resource.Resource) error, ...ModifyOption) error
+	ModifyWithResult(context.Context, resource.Resource, func(resource.Resource) error, ...ModifyOption) (resource.Resource, error)
+	Teardown(context.Context, resource.Pointer, ...DeleteOption) (bool, error)
+	Destroy(context.Context, resource.Pointer, ...DeleteOption) error
+
+	AddFinalizer(context.Context, resource.Pointer, ...resource.Finalizer) error
+	RemoveFinalizer(context.Context, resource.Pointer, ...resource.Finalizer) error
+}
+
+// ReaderWriter combines Reader and Writer interfaces.
+type ReaderWriter interface {
+	Reader
+	Writer
+}
+
+// DeleteOption for operation Teardown/Destroy.
+type DeleteOption func(*DeleteOptions)
+
+// DeleteOptions for operation Teardown/Destroy.
+type DeleteOptions struct {
+	Owner *string
+}
+
+// WithOwner allows to specify owner of the resource.
+func WithOwner(owner string) DeleteOption {
+	return func(o *DeleteOptions) {
+		o.Owner = &owner
+	}
+}
+
+// ToDeleteOptions converts variadic options to DeleteOptions.
+func ToDeleteOptions(opts ...DeleteOption) DeleteOptions {
+	var options DeleteOptions
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return options
+}
+
+// ModifyOption for operation Modify.
+type ModifyOption func(*ModifyOptions)
+
+// ModifyOptions for operation Modify.
+type ModifyOptions struct {
+	ExpectedPhase *resource.Phase
+}
+
+// WithExpectedPhase allows to specify expected phase of the resource.
+func WithExpectedPhase(phase resource.Phase) ModifyOption {
+	return func(o *ModifyOptions) {
+		o.ExpectedPhase = &phase
+	}
+}
+
+// WithExpectedPhaseAny allows to specify any phase of the resource.
+func WithExpectedPhaseAny() ModifyOption {
+	return func(o *ModifyOptions) {
+		o.ExpectedPhase = nil
+	}
+}
+
+// ToModifyOptions converts variadic options to ModifyOptions.
+func ToModifyOptions(opts ...ModifyOption) ModifyOptions {
+	phase := resource.PhaseRunning
+
+	options := ModifyOptions{
+		ExpectedPhase: &phase,
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return options
+}

--- a/pkg/state/owned/state.go
+++ b/pkg/state/owned/state.go
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package owned
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+// State enforces ownership of resources which are being created/modified via the state.
+type State struct {
+	state state.State
+	owner string
+}
+
+// New creates a new state which enforces ownership of resources.
+func New(state state.State, owner string) *State {
+	return &State{
+		state: state,
+		owner: owner,
+	}
+}
+
+// Get is passthrough to the underlying state.
+func (st *State) Get(ctx context.Context, ptr resource.Pointer, opts ...state.GetOption) (resource.Resource, error) {
+	return st.state.Get(ctx, ptr, opts...)
+}
+
+// List is passthrough to the underlying state.
+func (st *State) List(ctx context.Context, kind resource.Kind, opts ...state.ListOption) (resource.List, error) {
+	return st.state.List(ctx, kind, opts...)
+}
+
+// ContextWithTeardown is passthrough to the underlying state.
+func (st *State) ContextWithTeardown(ctx context.Context, ptr resource.Pointer) (context.Context, error) {
+	return st.state.ContextWithTeardown(ctx, ptr)
+}
+
+// Create creates a resource in the state.
+//
+// Create enforces that the resource is owned by the designated owner.
+func (st *State) Create(ctx context.Context, res resource.Resource) error {
+	return st.state.Create(ctx, res, state.WithCreateOwner(st.owner))
+}
+
+// Update updates a resource in the state.
+//
+// Update enforces that the resource is owned by the designated owner.
+func (st *State) Update(ctx context.Context, res resource.Resource) error {
+	return st.state.Update(ctx, res, state.WithUpdateOwner(st.owner))
+}
+
+// Modify modifies a resource in the state.
+//
+// Modify enforces that the resource is owned by the designated owner.
+func (st *State) Modify(ctx context.Context, emptyResource resource.Resource, updateFunc func(resource.Resource) error, options ...ModifyOption) error {
+	_, err := st.ModifyWithResult(ctx, emptyResource, updateFunc, options...)
+
+	return err
+}
+
+// ModifyWithResult modifies a resource in the state and returns the modified resource.
+//
+// ModifyWithResult enforces that the resource is owned by the designated owner.
+func (st *State) ModifyWithResult(ctx context.Context, emptyResource resource.Resource, updateFunc func(resource.Resource) error, options ...ModifyOption) (resource.Resource, error) {
+	updateOptions := []state.UpdateOption{state.WithUpdateOwner(st.owner)}
+
+	modifyOptions := ToModifyOptions(options...)
+	if modifyOptions.ExpectedPhase != nil {
+		updateOptions = append(updateOptions, state.WithExpectedPhase(*modifyOptions.ExpectedPhase))
+	} else {
+		updateOptions = append(updateOptions, state.WithExpectedPhaseAny())
+	}
+
+	return st.state.ModifyWithResult(ctx, emptyResource, updateFunc, updateOptions...)
+}
+
+// Teardown tears down a resource in the state.
+//
+// Teardown enforces that the resource is owned by the designated owner.
+func (st *State) Teardown(ctx context.Context, resourcePointer resource.Pointer, opOpts ...DeleteOption) (bool, error) {
+	var opts []state.TeardownOption
+
+	opOpt := ToDeleteOptions(opOpts...)
+	if opOpt.Owner != nil {
+		opts = append(opts, state.WithTeardownOwner(*opOpt.Owner))
+	} else {
+		opts = append(opts, state.WithTeardownOwner(st.owner))
+	}
+
+	return st.state.Teardown(ctx, resourcePointer, opts...)
+}
+
+// Destroy destroys a resource in the state.
+//
+// Destroy enforces that the resource is owned by the designated owner.
+func (st *State) Destroy(ctx context.Context, resourcePointer resource.Pointer, opOpts ...DeleteOption) error {
+	var opts []state.DestroyOption
+
+	opOpt := ToDeleteOptions(opOpts...)
+	if opOpt.Owner != nil {
+		opts = append(opts, state.WithDestroyOwner(*opOpt.Owner))
+	} else {
+		opts = append(opts, state.WithDestroyOwner(st.owner))
+	}
+
+	return st.state.Destroy(ctx, resourcePointer, opts...)
+}
+
+// AddFinalizer adds finalizers to the resource.
+func (st *State) AddFinalizer(ctx context.Context, ptr resource.Pointer, finalizers ...resource.Finalizer) error {
+	return st.state.AddFinalizer(ctx, ptr, finalizers...)
+}
+
+// RemoveFinalizer removes finalizers from the resource.
+func (st *State) RemoveFinalizer(ctx context.Context, ptr resource.Pointer, finalizers ...resource.Finalizer) error {
+	return st.state.RemoveFinalizer(ctx, ptr, finalizers...)
+}
+
+// Check interfaces.
+var (
+	_ Reader = (*State)(nil)
+	_ Writer = (*State)(nil)
+)


### PR DESCRIPTION
The idea is to split the part which enforces the ownership (but skip things like rate-limiting protection and controller-specific access checks) into a separate package which has exactly same interface.

This allows one to easily build a `controller.Reader/Writer` out of `state.State` (e.g. in the unit-tests).