### PR TITLE
fix: set initial watch bookmark on "late watches"

### DIFF
--- a/pkg/controller/runtime/runtime.go
+++ b/pkg/controller/runtime/runtime.go
@@ -263,7 +263,7 @@ func (runtime *Runtime) watch(resourceNamespace resource.Namespace, resourceType
 
 	kind := resource.NewMetadata(resourceNamespace, resourceType, "", resource.Version{})
 
-	return runtime.state.WatchKindAggregated(runtime.runCtx, kind, runtime.watchCh)
+	return runtime.state.WatchKindAggregated(runtime.runCtx, kind, runtime.watchCh, state.WithBootstrapBookmark(true))
 }
 
 type dedup map[reduced.Metadata]struct{}


### PR DESCRIPTION
When the watch is established in the controller runtime after the runtime starts, make sure watch asks for the initial bookmark, so that the watch can be restarted on connection failure.