### PR TITLE
refactor: remove type parameter from destroy controller

### DIFF
--- a/pkg/controller/generic/destroy/destroy.go
+++ b/pkg/controller/generic/destroy/destroy.go
@@ -15,45 +15,50 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic"
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/state"
 )
 
 // Controller provides a generic implementation of a QController which destroys tearing down resources without finalizers.
-type Controller[Input generic.ResourceWithRD] struct {
+type Controller struct {
 	generic.NamedController
-	concurrency optional.Optional[uint]
+	resourceType     resource.Type
+	defaultNamespace resource.Namespace
+	concurrency      optional.Optional[uint]
 }
 
-// NewController creates a new destroy Controller.
-func NewController[Input generic.ResourceWithRD](concurrency optional.Optional[uint]) *Controller[Input] {
+// NewController creates a new destroy Controller for the resource type given as a type parameter.
+func NewController[Input generic.ResourceWithRD](concurrency optional.Optional[uint]) *Controller {
 	var input Input
 
-	name := fmt.Sprintf("Destroy[%s]", input.ResourceDefinition().Type)
+	return NewControllerForResource(input.ResourceDefinition(), concurrency)
+}
 
-	return &Controller[Input]{
-		concurrency: concurrency,
+// NewControllerForResource creates a new destroy Controller for the resource described by the given definition.
+func NewControllerForResource(rd meta.ResourceDefinitionSpec, concurrency optional.Optional[uint]) *Controller {
+	return &Controller{
+		resourceType:     rd.Type,
+		defaultNamespace: rd.DefaultNamespace,
+		concurrency:      concurrency,
 		NamedController: generic.NamedController{
-			ControllerName: name,
+			ControllerName: fmt.Sprintf("Destroy[%s]", rd.Type),
 		},
 	}
 }
 
 // Settings implements controller.QController interface.
-func (ctrl *Controller[Input]) Settings() controller.QSettings {
-	var input Input
-
+func (ctrl *Controller) Settings() controller.QSettings {
 	return controller.QSettings{
 		Inputs: []controller.Input{
 			{
-				Namespace: input.ResourceDefinition().DefaultNamespace,
-				Type:      input.ResourceDefinition().Type,
+				Namespace: ctrl.defaultNamespace,
+				Type:      ctrl.resourceType,
 				Kind:      controller.InputQPrimary,
 			},
 		},
 		Outputs: []controller.Output{
 			{
-				Type: input.ResourceDefinition().Type,
+				Type: ctrl.resourceType,
 				Kind: controller.OutputShared,
 			},
 		},
@@ -62,8 +67,8 @@ func (ctrl *Controller[Input]) Settings() controller.QSettings {
 }
 
 // Reconcile implements controller.QController interface.
-func (ctrl *Controller[Input]) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
-	in, err := safe.ReaderGet[Input](ctx, r, ptr)
+func (ctrl *Controller) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	in, err := r.Get(ctx, ptr)
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return nil
@@ -93,6 +98,6 @@ func (ctrl *Controller[Input]) Reconcile(ctx context.Context, logger *zap.Logger
 }
 
 // MapInput implements controller.QController interface.
-func (ctrl *Controller[Input]) MapInput(context.Context, *zap.Logger, controller.QRuntime, controller.ReducedResourceMetadata) ([]resource.Pointer, error) {
+func (ctrl *Controller) MapInput(context.Context, *zap.Logger, controller.QRuntime, controller.ReducedResourceMetadata) ([]resource.Pointer, error) {
 	return nil, nil
 }

--- a/pkg/controller/generic/destroy/destroy_test.go
+++ b/pkg/controller/generic/destroy/destroy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic/destroy"
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/future"
@@ -94,47 +95,65 @@ func runTest(t *testing.T, f func(ctx context.Context, t *testing.T, st state.St
 }
 
 func TestFlow(t *testing.T) {
-	runTest(t, func(ctx context.Context, t *testing.T, st state.State, rt *runtime.Runtime) {
-		ctrl := destroy.NewController[*A](optional.Some(uint(1)))
+	for _, tt := range []struct {
+		ctrl func() controller.QController
+		name string
+	}{
+		{
+			name: "typed",
+			ctrl: func() controller.QController {
+				return destroy.NewController[*A](optional.Some(uint(1)))
+			},
+		},
+		{
+			name: "for-resource",
+			ctrl: func() controller.QController {
+				return destroy.NewControllerForResource(AE{}.ResourceDefinition(), optional.Some(uint(1)))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runTest(t, func(ctx context.Context, t *testing.T, st state.State, rt *runtime.Runtime) {
+				require.NoError(t, rt.RegisterQController(tt.ctrl()))
 
-		require.NoError(t, rt.RegisterQController(ctrl))
+				a := NewA("1")
 
-		a := NewA("1")
+				require.NoError(t, st.Create(ctx, a))
 
-		require.NoError(t, st.Create(ctx, a))
+				_, err := st.Teardown(ctx, a.Metadata())
+				require.NoError(t, err)
 
-		_, err := st.Teardown(ctx, a.Metadata())
-		require.NoError(t, err)
+				rtestutils.AssertNoResource[*A](ctx, t, st, "1")
 
-		rtestutils.AssertNoResource[*A](ctx, t, st, "1")
+				// should remain until we remove finalizers
 
-		// should remain until we remove finalizers
+				a = NewA("1")
 
-		a = NewA("1")
+				a.Metadata().Finalizers().Add("something")
 
-		a.Metadata().Finalizers().Add("something")
+				require.NoError(t, st.Create(ctx, a))
 
-		require.NoError(t, st.Create(ctx, a))
+				_, err = st.Teardown(ctx, a.Metadata())
+				require.NoError(t, err)
 
-		_, err = st.Teardown(ctx, a.Metadata())
-		require.NoError(t, err)
+				rtestutils.AssertResource[*A](ctx, t, st, "1", func(*A, *assert.Assertions) {})
 
-		rtestutils.AssertResource[*A](ctx, t, st, "1", func(*A, *assert.Assertions) {})
+				require.NoError(t, st.RemoveFinalizer(ctx, a.Metadata(), "something"))
 
-		require.NoError(t, st.RemoveFinalizer(ctx, a.Metadata(), "something"))
+				rtestutils.AssertNoResource[*A](ctx, t, st, "1")
 
-		rtestutils.AssertNoResource[*A](ctx, t, st, "1")
+				// owned resources are not touched
+				a = NewA("2")
 
-		// owned resources are not touched
-		a = NewA("2")
+				require.NoError(t, st.Create(ctx, a, state.WithCreateOwner("pwned")))
 
-		require.NoError(t, st.Create(ctx, a, state.WithCreateOwner("pwned")))
+				_, err = st.Teardown(ctx, a.Metadata(), state.WithTeardownOwner("pwned"))
+				require.NoError(t, err)
 
-		_, err = st.Teardown(ctx, a.Metadata(), state.WithTeardownOwner("pwned"))
-		require.NoError(t, err)
+				time.Sleep(time.Second)
 
-		time.Sleep(time.Second)
-
-		rtestutils.AssertResource[*A](ctx, t, st, "2", func(*A, *assert.Assertions) {})
-	})
+				rtestutils.AssertResource[*A](ctx, t, st, "2", func(*A, *assert.Assertions) {})
+			})
+		})
+	}
 }


### PR DESCRIPTION
The destroy controller does not need its input type parameter. The type was only used to recover the resource definition at construction time and to read the resource during reconcile, neither of which require static typing. Switch to a value-based constructor that takes a resource definition, and keep the typed constructor as a thin wrapper for back compatibility.

This allows registering destroy controllers in a loop over a list of resource types, instead of having to enumerate them at compile time.