### PR TITLE
feat: log and meter reconcile skips in QController runtime

### DIFF
--- a/pkg/controller/generic/qtransform/qtransform.go
+++ b/pkg/controller/generic/qtransform/qtransform.go
@@ -268,7 +268,7 @@ func (ctrl *QController[Input, Output]) reconcileRunning(ctx context.Context, lo
 		}
 
 		if xerrors.TagIs[SkipReconcileTag](err) {
-			return nil
+			return err
 		}
 
 		if xerrors.TagIs[DestroyOutputTag](err) {
@@ -328,10 +328,6 @@ func (ctrl *QController[Input, Output]) handleDestroyOutput(ctx context.Context,
 func (ctrl *QController[Input, Output]) reconcileTearingDown(ctx context.Context, logger *zap.Logger, r controller.QRuntime, in Input, outPtr resource.Pointer) error {
 	if ctrl.finalizerRemovalFunc != nil {
 		if err := ctrl.finalizerRemovalFunc(ctx, r, logger, in); err != nil {
-			if xerrors.TagIs[SkipReconcileTag](err) {
-				return nil
-			}
-
 			return err
 		}
 	}

--- a/pkg/controller/runtime/internal/qruntime/qitem.go
+++ b/pkg/controller/runtime/internal/qruntime/qitem.go
@@ -5,6 +5,8 @@
 package qruntime
 
 import (
+	"go.uber.org/zap/zapcore"
+
 	"github.com/cosi-project/runtime/pkg/controller/runtime/internal/reduced"
 	"github.com/cosi-project/runtime/pkg/resource"
 )
@@ -27,6 +29,15 @@ func (job QJob) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// LogLevel returns the log level used for reconcile-outcome logs of this job kind.
+func (job QJob) LogLevel() zapcore.Level {
+	if job == QJobMap {
+		return zapcore.DebugLevel
+	}
+
+	return zapcore.InfoLevel
 }
 
 // NewQItem creates a new QItem.

--- a/pkg/controller/runtime/internal/qruntime/qruntime.go
+++ b/pkg/controller/runtime/internal/qruntime/qruntime.go
@@ -15,12 +15,13 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
 	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
 	"github.com/cosi-project/runtime/pkg/controller/runtime/internal/adapter"
 	"github.com/cosi-project/runtime/pkg/controller/runtime/internal/controllerstate"
 	"github.com/cosi-project/runtime/pkg/controller/runtime/internal/qruntime/internal/queue"
@@ -273,10 +274,15 @@ func (adapter *Adapter) runReconcile(ctx context.Context) {
 				requeued = true
 			}
 
+			skipped := xerrors.TagIs[qtransform.SkipReconcileTag](reconcileError)
+
 			if adapter.metricsEnabled {
-				if reconcileError != nil {
+				switch {
+				case skipped:
+					metrics.QControllerSkips.Add(adapter.Name, 1)
+				case reconcileError != nil:
 					metrics.QControllerCrashes.Add(adapter.Name, 1)
-				} else if interval != 0 {
+				case interval != 0:
 					metrics.QControllerRequeues.Add(adapter.Name, 1)
 				}
 
@@ -287,7 +293,17 @@ func (adapter *Adapter) runReconcile(ctx context.Context) {
 				}
 			}
 
-			if reconcileError != nil {
+			switch {
+			case skipped:
+				adapter.clearBackoff(item.Key())
+
+				logger.Log(item.Key().job.LogLevel(), "reconcile skipped",
+					zap.String("reason", reconcileError.Error()),
+					zap.Duration("busy", busy),
+					zapSkipIfZero(interval, zap.Duration("interval", interval)),
+					zapSkipIfZero(requeued, zap.Bool("requeued", requeued)),
+				)
+			case reconcileError != nil:
 				if interval == 0 {
 					interval = adapter.getBackoffInterval(item.Key())
 				}
@@ -298,16 +314,10 @@ func (adapter *Adapter) runReconcile(ctx context.Context) {
 					zap.Duration("busy", busy),
 					zapSkipIfZero(requeued, zap.Bool("requeued", requeued)),
 				)
-			} else {
+			default:
 				adapter.clearBackoff(item.Key())
 
-				level := zapcore.InfoLevel
-
-				if item.Key().job == QJobMap {
-					level = zapcore.DebugLevel
-				}
-
-				logger.Log(level, "reconcile succeeded",
+				logger.Log(item.Key().job.LogLevel(), "reconcile succeeded",
 					zap.Duration("busy", busy),
 					zapSkipIfZero(interval, zap.Duration("interval", interval)),
 					zapSkipIfZero(requeued, zap.Bool("requeued", requeued)),

--- a/pkg/controller/runtime/metrics/metrics.go
+++ b/pkg/controller/runtime/metrics/metrics.go
@@ -29,6 +29,9 @@ var (
 	// QControllerCrashes counts the number of crashes per QController.
 	QControllerCrashes = expvar.NewMap("qcontroller_crashes")
 
+	// QControllerSkips counts the number of skipped reconcile events per QController.
+	QControllerSkips = expvar.NewMap("qcontroller_skips")
+
 	// QControllerRequeues counts the number of requeue events per QController.
 	QControllerRequeues = expvar.NewMap("qcontroller_requeues")
 


### PR DESCRIPTION
Previously qtransform swallowed `SkipReconcileTag` errors and returned nil, so the QRuntime saw a plain success and the reason behind the skip was lost. The runtime now detects the tag itself, emits a dedicated `reconcile skipped` log line carrying the original reason, and increments a new `qcontroller_skips` expvar metric — while still treating the cycle like a success for backoff purposes.
