### PR TITLE
test: use correct context to avoid race in TestContextWithTeardown

### DIFF
--- a/pkg/state/conformance/state.go
+++ b/pkg/state/conformance/state.go
@@ -1384,7 +1384,7 @@ func (suite *StateSuite) TestContextWithTeardown() {
 	assertContextIsNotCanceled(suite.T(), ctx1)
 	assertContextIsNotCanceled(suite.T(), ctx2)
 
-	suite.Require().NoError(suite.State.Destroy(ctx1, path1.Metadata()))
+	suite.Require().NoError(suite.State.Destroy(ctx, path1.Metadata()))
 
 	assertContextIsCanceled(suite.T(), ctx1)
 	assertContextIsNotCanceled(suite.T(), ctx2)


### PR DESCRIPTION
Use correct context to avoid race in TestContextWithTeardown