### PR TITLE
fix: properly handle finalizers empty watch in TeardownAndDestroy call

### DIFF
--- a/pkg/state/teardown_and_destroyer_test.go
+++ b/pkg/state/teardown_and_destroyer_test.go
@@ -7,11 +7,13 @@ package state_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -118,6 +120,62 @@ func TestCoreWrapperTeardownAndDestroyFallback(t *testing.T) {
 	_, err = st.Get(ctx, other.Metadata())
 	require.Error(t, err)
 	assert.True(t, state.IsNotFoundError(err))
+}
+
+func TestCoreWrapperTeardownAndDestroyRacyDestroy(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	r := conformance.NewPathResource("default", "/tmp")
+	require.NoError(t, st.Create(ctx, r))
+	require.NoError(t, st.AddFinalizer(ctx, r.Metadata(), "fin"))
+
+	var eg errgroup.Group
+
+	t.Cleanup(func() {
+		require.NoError(t, eg.Wait())
+
+		_, err := st.Get(ctx, r.Metadata())
+		require.Error(t, err)
+		assert.True(t, state.IsNotFoundError(err))
+	})
+
+	eg.Go(func() error {
+		events := make(chan state.Event)
+
+		err := st.Watch(ctx, r.Metadata(), events)
+		if err != nil {
+			return fmt.Errorf("watch failed: %w", err)
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case ev := <-events:
+				if ev.Resource.Metadata().Phase() == resource.PhaseTearingDown {
+					return st.RemoveFinalizer(ctx, r.Metadata(), "fin")
+				}
+			}
+		}
+	})
+
+	for i := range 10 {
+		t.Run(fmt.Sprintf("teardownAndDestroy-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			err := st.TeardownAndDestroy(ctx, r.Metadata())
+			if state.IsNotFoundError(err) || state.IsPhaseConflictError(err) {
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 // TestTeardownAndDestroyerInterfaceAssertion ensures TeardownAndDestroyer is

--- a/pkg/state/wrap.go
+++ b/pkg/state/wrap.go
@@ -248,12 +248,50 @@ func (state coreWrapper) TeardownAndDestroy(ctx context.Context, resourcePointer
 		return state.Destroy(ctx, resourcePointer, WithDestroyOwner(options.Owner))
 	}
 
-	_, err = state.WatchFor(ctx, resourcePointer, WithFinalizerEmpty())
+	destroyed, err := state.waitFinalizersEmpty(ctx, resourcePointer)
 	if err != nil {
 		return err
 	}
 
+	if destroyed {
+		return nil
+	}
+
 	return state.Destroy(ctx, resourcePointer, WithDestroyOwner(options.Owner))
+}
+
+func (state coreWrapper) waitFinalizersEmpty(ctx context.Context, resourcePointer resource.Pointer) (bool, error) {
+	ch := make(chan Event)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if err := state.Watch(ctx, resourcePointer, ch); err != nil {
+		return false, err
+	}
+
+	for {
+		var event Event
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case event = <-ch:
+		}
+
+		switch event.Type {
+		case Destroyed:
+			return true, nil
+		case Created, Updated:
+			if event.Resource != nil && event.Resource.Metadata().Finalizers().Empty() {
+				return false, nil
+			}
+		case Errored:
+			return false, event.Error
+		case Bootstrapped, Noop:
+			// ignore
+		}
+	}
 }
 
 // Modify modifies an existing resource or creates a new one.


### PR DESCRIPTION
`TeardownAndDestroy` hangs if `Teardown` and `Destroy` is called concurrently from two different actors.
Just `WatchFor` with `WithFinalizersEmpty` doesn't catch the moment when the resource is destroyed by another actor. Replace it with another fine carved method for that.
Also add reproducer tests.